### PR TITLE
Allow `user_id` opt in the `manageLink` request body

### DIFF
--- a/Provisioning-API.md
+++ b/Provisioning-API.md
@@ -24,6 +24,7 @@ Only used for PUT
 
 | Option          | Description    |
 | :-------------  | :------------- |
+| user_id | The user ID to use instead of passing the query parameter `userId`, above. |
 | exclude_replies | Don't show replies to mentions by the user. |
 
 ### Return Codes

--- a/src/Provisioner.js
+++ b/src/Provisioner.js
@@ -91,7 +91,7 @@ class Provisioner {
   }
 
   * _manageLink (self, req) {
-    const user_id = req.query.userId;
+    const user_id = req.query.userId || req.body.user_id;
     const room_id = req.params.roomId;
     const type = req.params.type; //Type of link to create/remove (one of timeline, hashtag)
     const name = req.params.name; //Name of the timeline/hashtag to use.


### PR DESCRIPTION
For the link endpoints, optionally allow a user_id, that will only be used if the userId query parameter is not set.