### PR TITLE
Add the option of exposing prometheus-style metrics from /metrics

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -34,3 +34,6 @@ logging:
 provisioning: # Provisioning system for scalar-enabled clients such as Riot.
   enable: true # Enable the system. This does not disable existing registered rooms.
   required_power_level: 50 # Required power level to bridge to rooms. Defaults to 50.
+
+metrics: # Expose prometheus-style bridge statistics from '/metrics'
+  enable: true

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -69,3 +69,8 @@ properties:
               type: "boolean"
             required_power_level:
               type: "integer"
+    metrics:
+      type: "object"
+      properties:
+        enable:
+          type: "boolean"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "mime-types": "^2.1.12",
     "npmlog": "^3.0.0",
     "oauth": "^0.9.14",
+    "prometheus-client": "^0.1.1",
     "request": "^2.76.0",
     "sqlite3": "^3.1.4",
     "twitter": "^1.3.0"

--- a/twitter-as.js
+++ b/twitter-as.js
@@ -79,6 +79,10 @@ var cli = new AppService.Cli({
 
     var tstorage = new TwitterDB(config.bridge.database_file || "twitter.db");
 
+    if (config.metrics && config.metrics.enable) {
+      bridge.getPrometheusMetrics();
+      log.info("Init", "Prometheus metrics enabled");
+    }
 
     twitter = new Twitter(bridge, config, tstorage);
     var opt = {


### PR DESCRIPTION
If metrics are enabled (see config.sample.yaml) expose a HTTP GET endpoint /metrics which serves statistics in a prometheus-like format.