### PR TITLE
Allow alternative bot IDs !== '@_twitter_bot:domain.name'

### DIFF
--- a/src/twitter/Twitter.js
+++ b/src/twitter/Twitter.js
@@ -287,7 +287,7 @@ class Twitter {
       }
       var intent = this._bridge.getIntent();
       var users = {};
-      users["@_twitter_bot:"+this._bridge.opts.domain] = 100;
+      users[this._bridge.getBot().getUserId()] = 100;
       users[user] = 100;
       var powers = util.roomPowers(users);
       //Create the room


### PR DESCRIPTION
Instead of hard-coding the assumed bot ID, get the ID through the matrix bridge API.