### PR TITLE
Invalidate internal cache on unOAuth

### DIFF
--- a/src/Provisioner.js
+++ b/src/Provisioner.js
@@ -426,10 +426,7 @@ class Provisioner {
       const url = yield this._account_services._oauth_getUrl(user_id, access_type, oauth_callback);
       return {body: {url: url}};
     } catch (err) {
-      if (err.statusCode) {
-        throw new Error(`Got status code ${err.statusCode} whilst trying to get OAuth URL.`);
-      }
-      throw err;
+      return {err: 500, body: {error: err.message}};
     }
   }
 
@@ -453,7 +450,7 @@ class Provisioner {
       return {err: 404, body: {error: "User ID not recognised."}};
     }
     if (client_data.twitter_id === "") {
-      return {err: 401, body: {error: "User ID does not have an associated twitter ID, please OAuth."}};
+      return {err: 401, body: {error: "User has not completed the OAuth process."}};
     }
     const profile = yield this._twitter.get_profile_by_id(client_data.twitter_id);
     if (!profile) {

--- a/src/twitter/TwitterClientFactory.js
+++ b/src/twitter/TwitterClientFactory.js
@@ -176,6 +176,18 @@ class TwitterClientFactory {
     });
   }
 
+  /**
+   * Remove a authenticated twitter client for a user from the cache.
+   *
+   * @param  {string} sender Matrix UserID of the user.
+   */
+  invalidate_twitter_client (sender) {
+    if (!this._tclients.has(sender)) {
+      return;
+    }
+    this._tclients.delete(sender);
+  }
+
   _create_twitter_client (creds) {
     var client = new Twitter({
       consumer_key: this._auth_config.consumer_key,


### PR DESCRIPTION
This fixes the case experienced when a previous twitter client is cached for a given user_id who has successfully unOAuthed, and then re OAuths only to see that the previous twitter client is still cached for them.

(Fixes https://github.com/Half-Shot/matrix-appservice-twitter/issues/46)