### PR TITLE
Fix to use correct user id when uploading media

### DIFF
--- a/src/TweetProcessor.js
+++ b/src/TweetProcessor.js
@@ -124,7 +124,7 @@ class TweetProcessor {
           util.uploadContentFromUrl(
             this._bridge,
             media.media_url_https,
-            this._bridge.getIntentFromLocalpart("_twitter_" + tweet.id_str)
+            this._bridge.getIntent(muser)
           ).then( (obj) => {
             media_info.size = obj.size;
             return {


### PR DESCRIPTION
Instead of recreating user IDs, reuse the one used for posting messages.