### PR TITLE
Add config timelines.shouldSyncInitially

### DIFF
--- a/twitter-as.js
+++ b/twitter-as.js
@@ -34,6 +34,11 @@ var cli = new AppService.Cli({
   run: function (port, config) {
     log.init(config.logging);
 
+    // Set default config
+    if (config.timelines.shouldSyncInitially === undefined) {
+      config.timelines.shouldSyncInitially = true;
+    }
+
     //Read registration file
     var regObj = yaml.safeLoad(fs.readFileSync("twitter-registration.yaml", 'utf8'));
     regObj = AppService.AppServiceRegistration.fromObject(regObj);
@@ -152,7 +157,7 @@ var cli = new AppService.Cli({
 
           if(type === 'timeline' && config.timelines.enable) {
             const exclude_replies = entry.remote.data.twitter_exclude_replies;
-            twitter.timeline.add_timeline(entry.remote.data.twitter_user, entry.matrix.getId(), {exclude_replies});
+            twitter.timeline.add_timeline(entry.remote.data.twitter_user, entry.matrix.getId(), {exclude_replies, is_new: !config.timelines.shouldSyncInitially});
           }
           else if(type === 'hashtag' && config.hashtags.enable) {
             twitter.timeline.add_hashtag(entry.remote.roomId.substr("hashtag_".length), entry.matrix.getId());


### PR DESCRIPTION
Prevent 100 tweets per timeline being polled for on startup if this is set to false. Default to true for backwards compat.

If set to false, the first poll for a timeline (on startup `tline.hasProcessedTweets = false`, on provision or DB deletion, since = null) will be done with `req.count = 1`, so that only one tweet is received. This tweet is the most recent tweet and is not bridged, but it's `since` is stored so that future polls will be restricted to tweets that were created after startup.