### PR TITLE
Use the new form of logging with tests

### DIFF
--- a/src/Provisioner.js
+++ b/src/Provisioner.js
@@ -1,7 +1,6 @@
 /*eslint no-invalid-this: 0*/ // eslint doesn't understand Promise.coroutine wrapping
 const log = require('./logging.js');
 const util = require('./util.js');
-const log = util.logPrefix("Provisioner");
 const Promise = require('bluebird');
 
 const RemoteRoom = require("matrix-appservice-bridge").RemoteRoom;

--- a/src/logging.js
+++ b/src/logging.js
@@ -18,15 +18,23 @@ function init (loggingConfig) {
     level: loggingConfig.level,
   }));
 
-  const logrotateConfig = {
-    file: loggingConfig.file,
-    json: false,
-    size: loggingConfig.size,
-    keep: loggingConfig.count,
-    compress: loggingConfig.compress,
-  };
+  if (loggingConfig && loggingConfig.file) {
+    const logrotateConfig = {
+      file: loggingConfig.file,
+      json: false,
+      size: loggingConfig.size,
+      keep: loggingConfig.count,
+      compress: loggingConfig.compress,
+      timestamp: () => new Date().toISOString().replace(/[TZ]/g, ' '),
+      formatter: function (options) {
+        return options.timestamp() + options.level + ' ' + (options.message ? options.message : '') +
+          (options.meta && Object.keys(options.meta).length ? '\n\t'+ JSON.stringify(options.meta) : '' );
+      },
+      level: loggingConfig.level,
+    };
+    transports.push(new Rotate(logrotateConfig));
+  }
 
-  transports.push(new Rotate(logrotateConfig));
 
   log = new winston.Logger({
     transports: transports,

--- a/src/util.js
+++ b/src/util.js
@@ -167,17 +167,6 @@ function isTwitterHashtag (str) {
   return /^[a-zA-Z0-9_]+$/.test(str);
 }
 
-function logPrefix (prefix) {
-  const levels = ["silly", "verbose", "info", "warn", "error"];
-  const logObject = { }
-  for(const level of levels) {
-    logObject[level] = (msg, ...args) => {
-      log.log(level, prefix, msg, args);
-    }
-  }
-  return logObject;
-}
-
 module.exports = {
   uploadContentFromUrl,
   downloadFile,
@@ -188,5 +177,4 @@ module.exports = {
   roomPowers,
   isTwitterScreenName,
   isTwitterHashtag,
-  logPrefix
 }

--- a/test/db/test_dm.js
+++ b/test/db/test_dm.js
@@ -3,6 +3,8 @@ chai.use(require("chai-as-promised"));
 const assert = chai.assert;
 const TwitterDB = require('../../src/TwitterDB.js');
 
+// Initialise logging
+require('../../src/logging.js').init({level: 'silent'});
 
 describe('TwitterDB.dm', function () {
   var db;

--- a/test/db/test_event.js
+++ b/test/db/test_event.js
@@ -4,6 +4,8 @@ const assert = chai.assert;
 const TwitterDB = require('../../src/TwitterDB.js');
 global.Promise = require('bluebird');
 
+// Initialise logging
+require('../../src/logging.js').init({level: 'silent'});
 
 describe('TwitterDB.dm', function () {
   var db;

--- a/test/handlers/test_AccountServices.js
+++ b/test/handlers/test_AccountServices.js
@@ -3,6 +3,9 @@
 // const assert = chai.assert;
 // const AccountServices = require('../../src/handlers/AccountServices.js');
 
+// Initialise logging
+require('../../src/logging.js').init({level: 'silent'});
+
 describe('AccountServices', function () {
 
 });

--- a/test/test_Provisioner.js
+++ b/test/test_Provisioner.js
@@ -1,6 +1,9 @@
 const assert = require('chai').assert;
 const Provisioner = require('../src/Provisioner.js');
 
+// Initialise logging
+require('../src/logging.js').init({level: 'silent'});
+
 const _bridge = {
   appService: {
     app: {

--- a/test/test_TwitterRoomHandler.js
+++ b/test/test_TwitterRoomHandler.js
@@ -3,6 +3,9 @@ chai.use(require("chai-as-promised"));
 const assert = chai.assert;
 const TwitterRoomHandler = require('../src/TwitterRoomHandler.js');
 
+// Initialise logging
+require('../src/logging.js').init({level: 'silent'});
+
 var bridge_room_entries;
 
 const bridge = {

--- a/test/test_db.js
+++ b/test/test_db.js
@@ -1,8 +1,8 @@
 const assert = require('chai').assert;
 const TwitterDB = require('../src/TwitterDB.js');
-const log = require('npmlog');
-log.level = "silent";
 
+// Initialise logging
+require('../src/logging.js').init({level: 'silent'});
 
 describe('TwitterDB', function () {
   describe('constructor()', () => {

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -4,6 +4,8 @@ const assert = chai.assert;
 const nock = require('nock');
 const util = require('../src/util.js');
 
+// Initialise logging
+require('../src/logging.js').init({level: 'silent'});
 
 describe('Util', function () {
 

--- a/test/twitter/test_Status.js
+++ b/test/twitter/test_Status.js
@@ -3,6 +3,9 @@ chai.use(require("chai-as-promised"));
 const assert = chai.assert;
 const Status = require('../../src/twitter/Status.js');
 
+// Initialise logging
+require('../../src/logging.js').init({level: 'silent'});
+
 var notified = false;
 
 const twitter = {


### PR DESCRIPTION
Tests were complaining about not having `npmlog`, but it was never used anyway. .src/logging.js was also complaining about it not being initialised.