### PR TITLE
Check for empty rooms before polling tweets.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@
     extends: "eslint:recommended",
 
     rules: {
+      no-var: 1,
       prefer-const: 2,
       curly: "error",
       max-lines: ["warn",{

--- a/.eslintrc
+++ b/.eslintrc
@@ -37,5 +37,6 @@
       }],
       eqeqeq: ["error", "smart"],
       space-infix-ops: ["error"],
+      camelcase: ["warn", { "properties": "never" }],
     }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -35,6 +35,7 @@
         "beforeColon": false,
         "afterColon": true
       }],
-      eqeqeq: ["error", "smart"]
+      eqeqeq: ["error", "smart"],
+      space-infix-ops: ["error"],
     }
 }

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -10,9 +10,10 @@ app_auth: # Get these from twitter by creating an application through the API si
 hashtags:
   enable: true # Enable processing hashtag rooms and creating new ones
   admin_only: false # NOT USED. Only an admin listed can create these rooms.
-
+  poll_if_empty: false # Poll the timeline, even if the room is empty
 timelines:
   enable: true # Enable processing timeline rooms and creating new ones
+  poll_if_empty: false # Poll the timeline, even if the room is empty
   # NOT CURRENTLY IN USE
   # admin_only: false. Only an admin listed can create these rooms.
 

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -10,11 +10,11 @@ app_auth: # Get these from twitter by creating an application through the API si
 hashtags:
   enable: true # Enable processing hashtag rooms and creating new ones
   poll_if_empty: false # Poll the timeline, even if the room is empty
-  single_account_fallback: false # Use a single account if a bunch of new accounts join.
+  single_account_fallback: false # Use a single account if a bunch of new members join.
 timelines:
   enable: true # Enable processing timeline rooms and creating new ones
   poll_if_empty: false # Poll the timeline, even if the room is empty
-
+  single_account_fallback: false # Use a single account if a bunch of new members join.
 
 media:
   enable_download: true # Enable download of media attached to tweets

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -11,10 +11,14 @@ hashtags:
   enable: true # Enable processing hashtag rooms and creating new ones
   poll_if_empty: false # Poll the timeline, even if the room is empty
   single_account_fallback: false # Use a single account if a bunch of new members join.
+
 timelines:
   enable: true # Enable processing timeline rooms and creating new ones
   poll_if_empty: false # Poll the timeline, even if the room is empty
   single_account_fallback: false # Use a single account if a bunch of new members join.
+
+rooms:
+  member_join_threshold: 15 # Amount of members allowed to join per minute
 
 media:
   enable_download: true # Enable download of media attached to tweets

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -9,17 +9,12 @@ app_auth: # Get these from twitter by creating an application through the API si
 
 hashtags:
   enable: true # Enable processing hashtag rooms and creating new ones
-  admin_only: false # NOT USED. Only an admin listed can create these rooms.
   poll_if_empty: false # Poll the timeline, even if the room is empty
+  single_account_fallback: false # Use a single account if a bunch of new accounts join.
 timelines:
   enable: true # Enable processing timeline rooms and creating new ones
   poll_if_empty: false # Poll the timeline, even if the room is empty
-  # NOT CURRENTLY IN USE
-  # admin_only: false. Only an admin listed can create these rooms.
 
-# NOT CURRENTLY IN USE.
-# admins: List of users that can modify the bridge.
-#  - @test:localhost
 
 media:
   enable_download: true # Enable download of media attached to tweets

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -40,6 +40,12 @@ properties:
             type: "boolean"
           single_account_fallback:
             type: "boolean"
+    rooms:
+      type: "object"
+      required: []
+      properties:
+        member_join_threshold:
+          type: "integer"
     media:
         type: "object"
         required: ["enable_download","enable_profile_images"]

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -38,6 +38,8 @@ properties:
             type: "boolean"
           poll_if_empty:
             type: "boolean"
+          single_account_fallback:
+            type: "boolean"
     media:
         type: "object"
         required: ["enable_download","enable_profile_images"]

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -28,7 +28,7 @@ properties:
             type: "boolean"
           poll_if_empty:
             type: "boolean"
-          admin_only:
+          single_account_fallback:
             type: "boolean"
     timelines:
         type: "object"
@@ -37,8 +37,6 @@ properties:
           enable:
             type: "boolean"
           poll_if_empty:
-            type: "boolean"
-          admin_only:
             type: "boolean"
     media:
         type: "object"

--- a/src/Provisioner.js
+++ b/src/Provisioner.js
@@ -5,8 +5,8 @@ const Promise = require('bluebird');
 const RemoteRoom = require("matrix-appservice-bridge").RemoteRoom;
 const MatrixRoom = require("matrix-appservice-bridge").MatrixRoom;
 
-const LEAVE_UNPROVIS_AFTER_MS = 10*60*1000;
-const ROOM_JOIN_TIMEOUT_MS = 1*60*1000;
+const LEAVE_UNPROVIS_AFTER_MS = 10 * 60 * 1000;
+const ROOM_JOIN_TIMEOUT_MS = 1 * 60 * 1000;
 const DEFAULT_POWER_REQ = 50;
 
 class Provisioner {

--- a/src/Provisioner.js
+++ b/src/Provisioner.js
@@ -282,7 +282,7 @@ class Provisioner {
       log.info("Reconfiguring %s %s", profile.id_str, room_id);
       //Reconfigure and bail.
       this._twitter.timeline.remove_timeline(profile.id_str, room_id);
-      var entry = rooms[0];
+      const entry = rooms[0];
       entry.remote.set("twitter_exclude_replies", opts.exclude_replies);
       roomstore.upsertEntry(entry);
       this._twitter.timeline.add_timeline(profile.id_str, room_id, {
@@ -292,7 +292,7 @@ class Provisioner {
       return {err: 201, body: {message: "Link updated."}};
     }
 
-    var remote = new RemoteRoom("timeline_" + profile.id_str);
+    const remote = new RemoteRoom("timeline_" + profile.id_str);
     remote.set("twitter_type", "timeline");
     remote.set("twitter_user", profile.id_str);
     remote.set("twitter_exclude_replies", opts.exclude_replies);
@@ -318,7 +318,7 @@ class Provisioner {
       return {body: {message: "Hashtag already bridged!"}};
     }
 
-    var remote = new RemoteRoom("hashtag_" + hashtag);
+    const remote = new RemoteRoom("hashtag_" + hashtag);
     remote.set("twitter_type", "hashtag");
     remote.set("twitter_hashtag", hashtag);
     roomstore.linkRooms(new MatrixRoom(room_id), remote);
@@ -361,7 +361,7 @@ class Provisioner {
         err: 403, body: {message: "Couldn't join room. Perhaps room permissions are not set to public?"}
       });
     }
-    var powerState;
+    let powerState;
     try{
       powerState = yield matrixClient.getStateEvent(roomId, 'm.room.power_levels');
     }

--- a/src/TweetProcessor.js
+++ b/src/TweetProcessor.js
@@ -72,8 +72,8 @@ class TweetProcessor {
    * This function will fill the content structure for a new matrix message for a given tweet.
    *
    * @param  {TwitterTweet} tweet The tweet object from the Twitter API See {@link}
-   * @param  {type} type  The 'msgtype' of a message.
-   * @return {object}     The content of a Matrix 'm.room.message' event.
+   * @param  {Type} type  The 'msgtype' of a message.
+   * @return {Object}     The content of a Matrix 'm.room.message' event.
    *
    * @see {@link https://dev.twitter.com/overview/api/tweets}
    */
@@ -202,15 +202,13 @@ class TweetProcessor {
 
 
   /**
-   * A function used to process tweets and post them to rooms.
-   *
-   * @param  {type} rooms Rooms to post the tweets to.
-   * @param  {type} tweets Tweets to process
-   * @param  {type} opts.depth The maximum depth of the tweet chain (replies to
-   * replies) to be traversed. Set this to how deep you wish to traverse and it
-   * will be decreased when the function calls itself.
-   * @param  {type} opts.client = null The twitter authed client to use.
-   * @param  {string} opts.force_user_id Should we force one account to post for every tweet.
+   * Simliar to process_tweet but returns a promise for when all tweets have
+   * been sent. This function is intended to optimise the processing of
+   * tweets in a given array.
+   * @param  {String} rooms
+   * @param  {TwitterTweet[]} tweets
+   * @param  {Object} opts
+   * @see this.process_tweet()
    */
   process_tweets (rooms, tweets, opts) {
     if (opts == null) {
@@ -230,15 +228,22 @@ class TweetProcessor {
   }
 
   /**
-   * A function used to process a tweet and post them to rooms.
+   * Process a given tweet (including esolving any parent tweets),
+   * and submit it to the given room. This function is recursive,
+   * limited to the depth set.
    *
-   * @param  {type} rooms Rooms to post the tweets to.
-   * @param  {type} tweet Tweet to process
-   * @param  {type} opts.depth The maximum depth of the tweet chain (replies to
+   * @param  {String} rooms Matrix Room ID of the room that we are processing.
+   * @param  {TwitterTweet} tweet The tweet object from the Twitter API See {@link}
+   * @param  {Object} opts Options for the processor.
+   * @param  {Number} opts.depth The maximum depth of the tweet chain (replies to
    * replies) to be traversed. Set this to how deep you wish to traverse and it
    * will be decreased when the function calls itself.
-   * @param  {type} opts.client = null The twitter authed client to use.
-   * @param  {string} opts.force_user_id Should we force one account to post for every tweet.
+   * @param  {TwitterClient} opts.client = null The twitter authed client to use.
+   * @param  {String} opts.force_user_id Should we force one account to post for the tweet.
+   * @return {Promise}  A promise that resolves once the tweet has been queued.
+   *
+   * @see {@link https://dev.twitter.com/overview/api/tweets}
+   */
    */
   process_tweet (rooms, tweet, opts) {
     if (opts == null) {
@@ -254,20 +259,7 @@ class TweetProcessor {
   }
 
   /**
-   * TweetProcessor.prototype._process_tweet - Process a given tweet (including
-   * resolving any parent tweets), and submit it to the given room. This function
-   * is recursive, limited to the depth set.
-   *
-   * @param  {String} rooms Matrix Room ID of the room that we are processing.
-   * @param  {TwitterTweet} tweet The tweet object from the Twitter API See {@link}
-   * @param  {type} opts.depth The maximum depth of the tweet chain (replies to
-   * replies) to be traversed. Set this to how deep you wish to traverse and it
-   * will be decreased when the function calls itself.
-   * @param  {type} opts.client = null The twitter authed client to use.
-   * @param  {string} opts.force_user_id Should we force one account to post for every tweet.
-   * @return {Promise[]]}  A promise that resolves once the tweet has been queued.
-   *
-   * @see {@link https://dev.twitter.com/overview/api/tweets}
+   * @see this.process_tweet()
    */
   _process_tweet (rooms, tweet, depth, opts) {
     depth--;

--- a/src/TweetProcessor.js
+++ b/src/TweetProcessor.js
@@ -244,7 +244,6 @@ class TweetProcessor {
    *
    * @see {@link https://dev.twitter.com/overview/api/tweets}
    */
-   */
   process_tweet (rooms, tweet, opts) {
     if (opts == null) {
       opts = { }
@@ -289,16 +288,17 @@ class TweetProcessor {
       if(typeof rooms == "string") {
         rooms = [rooms];
       }
-      rooms.forEach((roomid) => {
-        this._storage.room_has_tweet(roomid, tweet.id_str).then(
+      return rooms.map((roomid) => {
+        return this._storage.room_has_tweet(roomid, tweet.id_str).then(
           (room_has_tweet) => {
             if (!room_has_tweet) {
               const realUserId = '_twitter_'+tweet.user.id_str;
               const userId = opts.force_user_id == null ? realUserId : opts.force_user_id
-              this._push_to_msg_queue(
+              return this._push_to_msg_queue(
                 userId, roomid, tweet, type, opts.force_user_id != null ? realUserId : null
               );
             }
+            return Promise.resolve();
           }
         );
       });

--- a/src/TweetProcessor.js
+++ b/src/TweetProcessor.js
@@ -240,7 +240,7 @@ class TweetProcessor {
    * will be decreased when the function calls itself.
    * @param  {TwitterClient} opts.client = null The twitter authed client to use.
    * @param  {String} opts.forceUserId Should we force one account to post for the tweet.
-   * @param  {String} opts.hotRooms Which rooms should be forced to use force_user_id.
+   * @param  {Set<string>} opts.hotRooms Which rooms should be forced to use force_user_id.
    * @return {Promise}  A promise that resolves once the tweet has been queued.
    *
    * @see {@link https://dev.twitter.com/overview/api/tweets}
@@ -289,10 +289,12 @@ class TweetProcessor {
         rooms = [rooms];
       }
       return [...rooms].map((roomid) => {
+        // Are we limiting joins on this room?
+        const forceUserId = opts.hotRooms.has(roomid) ? opts.forceUserId : null;
         return this._processTweetForRoom(
           roomid,
           tweet,
-          opts.hotRooms.has(roomid) ? opts.forceUserId : null);
+          forceUserId);
       });
     });
   }

--- a/src/TweetProcessor.js
+++ b/src/TweetProcessor.js
@@ -288,11 +288,12 @@ class TweetProcessor {
       if(typeof rooms == "string") {
         rooms = [rooms];
       }
-      return [...rooms].map((roomid) => {
+      // [...rooms] will allow us to map the Set by creating an array
+      return [...rooms].map((roomId) => {
         // Are we limiting joins on this room?
-        const forceUserId = opts.hotRooms.has(roomid) ? opts.forceUserId : null;
+        const forceUserId = opts.hotRooms.has(roomId) ? opts.forceUserId : null;
         return this._processTweetForRoom(
-          roomid,
+          roomId,
           tweet,
           forceUserId);
       });
@@ -305,7 +306,7 @@ class TweetProcessor {
    *
    * @param  {String} roomid The matrix roomid of the room.
    * @param  {TwitterTweet} tweet  description
-   * @param  {String} force_user_id   See process_tweet()
+   * @param  {String} forceUserId   See process_tweet()
    * @return {Promise}
    * @see process_tweet()
    */

--- a/src/TweetProcessor.js
+++ b/src/TweetProcessor.js
@@ -54,7 +54,7 @@ class TweetProcessor {
       }
       const msgs = this.msg_queue.pop();
       for(const msg of msgs) {
-        var intent = this._bridge.getIntent(msg.userId);
+        const intent = this._bridge.getIntent(msg.userId);
         promises.push(intent.sendEvent(msg.roomId, msg.type, msg.content).then(res => {
           if (msg.content.msgtype === "m.text" ) {
             this._storage.add_event(res.event_id, msg.userId, msg.roomId, msg.content.tweet_id, Date.now());
@@ -125,14 +125,14 @@ class TweetProcessor {
   }
 
   _push_to_msg_queue (muser, roomid, tweet, type) {
-    var time = Date.parse(tweet.created_at);
+    const time = Date.parse(tweet.created_at);
     let content;
     try {
       content = this.tweet_to_matrix_content(tweet, type)
     } catch (e) {
       return Promise.reject("Tweet was missing user field.", e);
     }
-    var newmsg = {
+    const newmsg = {
       userId: muser,
       roomId: roomid,
       time: time,
@@ -140,9 +140,9 @@ class TweetProcessor {
       content: content,
     };
 
-    var media_promises = [];
+    const media_promises = [];
     if(tweet.entities.hasOwnProperty("media") && this.media_cfg.enable_download) {
-      for(var media of tweet.entities.media) {
+      for(const media of tweet.entities.media) {
         if(media.type !== 'photo') {
           continue;
         }
@@ -179,7 +179,7 @@ class TweetProcessor {
 
     return Promise.all(media_promises).then(msgs =>{
       msgs.unshift(newmsg);
-      for(var m in this.msg_queue) {
+      for(const m in this.msg_queue) {
         if(newmsg.time > this.msg_queue[m].time) {
           this.msg_queue.splice(m, 0, msgs);
           return;
@@ -235,8 +235,8 @@ class TweetProcessor {
    */
   _process_tweet (rooms, tweet, depth, client) {
     depth--;
-    var type = "m.text";
-    var promise;
+    const type = "m.text";
+    let promise;
     if (tweet.in_reply_to_status_id_str != null && depth > 0) {
       promise = client.get('statuses/show/' + tweet.in_reply_to_status_id_str, {})
       .then((newtweet) => {

--- a/src/TwitterDB.js
+++ b/src/TwitterDB.js
@@ -28,8 +28,8 @@ class TwitterDB {
     handlers.timeline_room = require("./db/timeline_room.js");
     handlers.twitter_account = require("./db/twitter_account.js");
 
-    for(var handler of Object.keys(handlers)) {
-      for(var func of Object.keys(handlers[handler])) {
+    for(const handler of Object.keys(handlers)) {
+      for(const func of Object.keys(handlers[handler])) {
         this[func] = handlers[handler][func];
       }
     }
@@ -41,14 +41,14 @@ class TwitterDB {
    */
   init () {
     log.info("Starting DB Init");
-    var old_version;
-    var version;
+    let old_version;
+    let version;
     return this._get_schema_version().then(o =>{
       old_version = o;
       version = o;
       while(version < this._target_schema) {
         version++;
-        var schema = require(`./database_schema/v${version}.js`);
+        const schema = require(`./database_schema/v${version}.js`);
         schema.run(this);
         log.info("Updated database v%s", version);
         this.version = version;

--- a/src/TwitterRoomHandler.js
+++ b/src/TwitterRoomHandler.js
@@ -25,8 +25,8 @@ class TwitterRoomHandler {
   }
 
   processInvite (event, request, context) {
-    var remote = context.rooms.remote;
-    var twitbot = "@"+this._bridge.opts.registration.sender_localpart+":"+this._bridge.opts.domain;
+    const remote = context.rooms.remote;
+    const twitbot = "@"+this._bridge.opts.registration.sender_localpart+":"+this._bridge.opts.domain;
     if(event.sender === twitbot) {
       return;
     }
@@ -42,11 +42,11 @@ class TwitterRoomHandler {
   }
 
   processLeave (event, request, context) {
-    var remote = context.rooms.remote;
+    const remote = context.rooms.remote;
     if(remote == null) {
       return;
     }
-    var type = remote.data.twitter_type;
+    const type = remote.data.twitter_type;
 
     if(type === "service") {
       this.handlers.services.processLeave(event, request, context);
@@ -57,8 +57,8 @@ class TwitterRoomHandler {
   }
 
   passEvent (request, context) {
-    var event = request.getData();
-    var remote = context.rooms.remote;
+    const event = request.getData();
+    const remote = context.rooms.remote;
     if (event.type === "m.room.member") {
       if(event.membership === "invite") {
         this.processInvite(event, request, context);
@@ -93,8 +93,8 @@ class TwitterRoomHandler {
   }
 
   processAliasQuery (alias, aliasLocalpart) {
-    var type = aliasLocalpart.substr("_twitter_".length, 2);
-    var part = aliasLocalpart.substr("_twitter_.".length);
+    const type = aliasLocalpart.substr("_twitter_".length, 2);
+    const part = aliasLocalpart.substr("_twitter_.".length);
 
     //TODO: Check permissions for admins
     if(type[0] === '@' && this._timelines.enable) { //User timeline
@@ -110,13 +110,13 @@ class TwitterRoomHandler {
   }
 
   onRoomCreated (alias, roomId) {
-    var roomstore = this._bridge.getRoomStore();
+    const roomstore = this._bridge.getRoomStore();
     return roomstore.getEntriesByMatrixId(roomId).then(entries =>{
       if(entries.length === 0) {
         log.error("Got a onRoomCreated, but no remote is associated.");
         return;
       }
-      var type = entries[0].remote.data.twitter_type
+      const type = entries[0].remote.data.twitter_type
       if(type === "timeline") {
         this.handlers.timeline.onRoomCreated(alias, entries[0]);
       }

--- a/src/TwitterRoomHandler.js
+++ b/src/TwitterRoomHandler.js
@@ -26,7 +26,7 @@ class TwitterRoomHandler {
 
   processInvite (event, request, context) {
     const remote = context.rooms.remote;
-    const twitbot = "@"+this._bridge.opts.registration.sender_localpart+":"+this._bridge.opts.domain;
+    const twitbot = "@" + this._bridge.opts.registration.sender_localpart + ":" + this._bridge.opts.domain;
     if(event.sender === twitbot) {
       return;
     }

--- a/src/db/profile.js
+++ b/src/db/profile.js
@@ -19,8 +19,8 @@ module.exports = {
       $id: id
     }).then((profile) =>{
       if(profile !== undefined) {
-        var ts = new Date().getTime();
-        var pro = JSON.parse(profile.profile);
+        const ts = new Date().getTime();
+        const pro = JSON.parse(profile.profile);
         pro._outofdate =(ts - profile.timestamp >= TWITTER_PROFILE_INTERVAL_MS);
         return pro;
       }
@@ -50,8 +50,8 @@ module.exports = {
       $name: name
     }).then((profile) =>{
       if(profile !== undefined) {
-        var ts = new Date().getTime();
-        var pro = JSON.parse(profile.profile);
+        const ts = new Date().getTime();
+        const pro = JSON.parse(profile.profile);
         pro._outofdate =(ts - profile.timestamp >= TWITTER_PROFILE_INTERVAL_MS);
         return pro;
       }
@@ -76,8 +76,8 @@ module.exports = {
       $id: user_id
     }).then((profile) => {
       if(profile !== undefined) {
-        var ts = new Date().getTime();
-        var pro = JSON.parse(profile.profile);
+        const ts = new Date().getTime();
+        const pro = JSON.parse(profile.profile);
         pro._outofdate =(ts - profile.timestamp >= TWITTER_PROFILE_INTERVAL_MS);
         return pro;
       }

--- a/src/db/profile.js
+++ b/src/db/profile.js
@@ -21,7 +21,7 @@ module.exports = {
       if(profile !== undefined) {
         const ts = new Date().getTime();
         const pro = JSON.parse(profile.profile);
-        pro._outofdate =(ts - profile.timestamp >= TWITTER_PROFILE_INTERVAL_MS);
+        pro._outofdate = (ts - profile.timestamp >= TWITTER_PROFILE_INTERVAL_MS);
         return pro;
       }
       else {
@@ -52,7 +52,7 @@ module.exports = {
       if(profile !== undefined) {
         const ts = new Date().getTime();
         const pro = JSON.parse(profile.profile);
-        pro._outofdate =(ts - profile.timestamp >= TWITTER_PROFILE_INTERVAL_MS);
+        pro._outofdate = (ts - profile.timestamp >= TWITTER_PROFILE_INTERVAL_MS);
         return pro;
       }
       else {
@@ -78,7 +78,7 @@ module.exports = {
       if(profile !== undefined) {
         const ts = new Date().getTime();
         const pro = JSON.parse(profile.profile);
-        pro._outofdate =(ts - profile.timestamp >= TWITTER_PROFILE_INTERVAL_MS);
+        pro._outofdate = (ts - profile.timestamp >= TWITTER_PROFILE_INTERVAL_MS);
         return pro;
       }
       else {

--- a/src/db/twitter_account.js
+++ b/src/db/twitter_account.js
@@ -1,5 +1,5 @@
 const log = require('../logging.js');
-const TWITTER_PROFILE_INTERVAL_MS = 10*60000;
+const TWITTER_PROFILE_INTERVAL_MS = 10 * 60000;
 module.exports = {
   get_twitter_account: function (user_id) {
     log.silly("SQL", "get_twitter_account => %s", user_id);
@@ -51,7 +51,7 @@ module.exports = {
       if(profile !== undefined) {
         const ts = new Date().getTime();
         const pro = JSON.parse(profile.profile);
-        pro._outofdate =(ts - profile.timestamp >= TWITTER_PROFILE_INTERVAL_MS);
+        pro._outofdate = (ts - profile.timestamp >= TWITTER_PROFILE_INTERVAL_MS);
         return pro;
       }
       else {

--- a/src/db/twitter_account.js
+++ b/src/db/twitter_account.js
@@ -49,8 +49,8 @@ module.exports = {
       $id: user_id
     }).then((profile) => {
       if(profile !== undefined) {
-        var ts = new Date().getTime();
-        var pro = JSON.parse(profile.profile);
+        const ts = new Date().getTime();
+        const pro = JSON.parse(profile.profile);
         pro._outofdate =(ts - profile.timestamp >= TWITTER_PROFILE_INTERVAL_MS);
         return pro;
       }

--- a/src/handlers/AccountServices.js
+++ b/src/handlers/AccountServices.js
@@ -59,7 +59,7 @@ class AccountServices {
       backoff: 2,
       max_tries: RETRY_INVITE_COUNT
     }).then( () => {
-      var rroom = new RemoteRoom("service_"+event.sender);
+      const rroom = new RemoteRoom("service_"+event.sender);
       rroom.set("twitter_type", "service");
       this._bridge.getRoomStore().linkRooms(context.rooms.matrix, rroom);
       intent.sendMessage(event.room_id,
@@ -77,9 +77,9 @@ class AccountServices {
 
   processLeave (event, request, context) {
     log.info("User %s left room. Leaving", event.sender);
-    var intent = this._bridge.getIntent();
+    const intent = this._bridge.getIntent();
     intent.leave(event.room_id).then(() =>{
-      var roomstore = this._bridge.getRoomStore();
+      const roomstore = this._bridge.getRoomStore();
       roomstore.removeEntriesByRemoteRoomData(context.rooms.remote.data);
     });
   }
@@ -121,7 +121,7 @@ class AccountServices {
       this._processPIN(event);
     }
     else{
-      var intent = this._bridge.getIntent();
+      const intent = this._bridge.getIntent();
       intent.sendMessage(event.room_id, {
         "msgtype": "m.notice",
         "body": "Unknown command or invalid arguments"
@@ -130,7 +130,7 @@ class AccountServices {
   }
 
   _helpText (room_id) {
-    var intent = this._bridge.getIntent();
+    const intent = this._bridge.getIntent();
     intent.sendMessage(room_id, {
       "msgtype": "m.notice",
       "body":
@@ -216,8 +216,8 @@ ${dm_rooms}`
    * @param  {object} event The Matrix Event from the requesting user.
    */
   _beginLinkAccount (event) {
-    var intent = this._bridge.getIntent();
-    var access_type = event.content.body.substr("account.link ".length);
+    const intent = this._bridge.getIntent();
+    const access_type = event.content.body.substr("account.link ".length);
     if(!["read", "write", "dm"].includes(access_type)) {
       intent.sendMessage(event.room_id, {
         "body": "You must specify either read, write or dm access.",
@@ -249,7 +249,7 @@ ${dm_rooms}`
    * @param  {object} event The Matrix Event from the requesting user.
    */
   _unlinkAccount (event) {
-    var intent = this._bridge.getIntent();
+    const intent = this._bridge.getIntent();
     this._unlinkAccountbyUserId(event.sender).then(
       () => {
         intent.sendMessage(event.room_id, {
@@ -286,9 +286,9 @@ ${dm_rooms}`
    * @param  {object} event The Matrix Event from the requesting user.
    */
   _processPIN (event) {
-    var intent = this._bridge.getIntent();
+    const intent = this._bridge.getIntent();
     this._storage.get_twitter_account(event.sender).then((client_data) => {
-      var pin = event.content.body;
+      const pin = event.content.body;
       log.info(`${event.sender} sent a pin (${pin}) to auth with.`);
       if(client_data == null) {
         intent.sendMessage(event.room_id, {
@@ -351,7 +351,7 @@ ${dm_rooms}`
           }
           client_data.access_token = access_token;
           client_data.access_token_secret = access_token_secret;
-          var client = new Twitter({
+          const client = new Twitter({
             consumer_key: this._app_auth.consumer_key,
             consumer_secret: this._app_auth.consumer_secret,
             access_token_key: client_data.access_token,
@@ -411,7 +411,7 @@ ${dm_rooms}`
               }
               //We are modifying the data. So make sure to detach the rooms first.
               this._twitter.user_stream.detach(id);
-              var data = {
+              const data = {
                 oauth_token: oAuthToken,
                 oauth_secret: oAuthTokenSecret,
                 access_token: null,
@@ -419,7 +419,7 @@ ${dm_rooms}`
                 access_type: access_type
               };
               this._storage.set_twitter_account(id, "", data).then(()=>{
-                var authURL = 'https://twitter.com/oauth/authenticate?oauth_token=' + oAuthToken;
+                const authURL = 'https://twitter.com/oauth/authenticate?oauth_token=' + oAuthToken;
                 resolve(authURL);
               }).catch(() => {
                 reject(new Error("Failed to store account information."));
@@ -436,7 +436,7 @@ ${dm_rooms}`
   }
 
   _bridgeRoom (event) {
-    var args = event.content.body.split(" ");
+    const args = event.content.body.split(" ");
     if(args.length < 3) {
       return;//Not enough args.
     }
@@ -454,7 +454,7 @@ ${dm_rooms}`
       })
 
     });
-    var get_twitter_feed;
+    let get_twitter_feed;
     if(feed_id[0] === '#' && util.isTwitterHashtag(feed_id.substr(1))) {
       get_twitter_feed = Promise.resolve(feed_id.substr(1));//hashtag
     }
@@ -466,7 +466,7 @@ ${dm_rooms}`
     }
 
     get_twitter_feed.then(item => {
-      var remote;
+      let remote;
       if(typeof item == "string") {
         remote = new RemoteRoom("hashtag_" + item);
         remote.set("twitter_type", "hashtag");
@@ -574,7 +574,7 @@ ${dm_rooms}`
 
   _setFilter (event) {
     const intent = this._bridge.getIntent();
-    var option = event.content.body.substr("timeline.filter ".length);
+    const option = event.content.body.substr("timeline.filter ".length);
     if(['followings', 'user'].indexOf(option) === -1) {
       intent.sendMessage(event.room_id, {
         "msgtype": "m.notice",
@@ -599,7 +599,7 @@ ${dm_rooms}`
 
   _setReplies (event) {
     const intent = this._bridge.getIntent();
-    var option = event.content.body.substr("timeline.replies ".length);
+    const option = event.content.body.substr("timeline.replies ".length);
     if(['all', 'mutual'].indexOf(option) === -1) {
       intent.sendMessage(event.room_id, {
         "msgtype": "m.notice",

--- a/src/handlers/AccountServices.js
+++ b/src/handlers/AccountServices.js
@@ -59,7 +59,7 @@ class AccountServices {
       backoff: 2,
       max_tries: RETRY_INVITE_COUNT
     }).then( () => {
-      const rroom = new RemoteRoom("service_"+event.sender);
+      const rroom = new RemoteRoom("service_" + event.sender);
       rroom.set("twitter_type", "service");
       this._bridge.getRoomStore().linkRooms(context.rooms.matrix, rroom);
       intent.sendMessage(event.room_id,
@@ -90,7 +90,7 @@ class AccountServices {
    */
   processMessage (event) {
     const body = event.content.body.toLowerCase();
-    if (event.sender === "@"+this._sender_localpart+":" + this._bridge.opts.domain) {
+    if (event.sender === "@" + this._sender_localpart + ":" + this._bridge.opts.domain) {
       return;//Don't talk to ourselves.
     }
     if (body.startsWith("account.link ")) {
@@ -360,7 +360,7 @@ ${dm_rooms}`
           client.get("account/verify_credentials", (error, profile) =>{
             if(error) {
               log.error("Handler.AccountServices", `We couldn't authenticate with `
-            +`the supplied access token for ${user_id}. ${error}`);
+            + `the supplied access token for ${user_id}. ${error}`);
               reject("Twitter account could not be authenticated.");
               return;
             }

--- a/src/handlers/DirectMessageHandler.js
+++ b/src/handlers/DirectMessageHandler.js
@@ -28,8 +28,8 @@ class DirectMessageHandler {
    * @param  {Context} context Context given by the appservice.
    */
   processInvite (event, request, context) {
-    var user_id = context.senders.matrix.getId();
-    var sender, recipient, intentS, intentR = null;
+    const user_id = context.senders.matrix.getId();
+    let sender, recipient, intentS, intentR = null;
     return this.twitter.dm.can_use(context.senders.matrix.getId()).then(() =>{
       //Get the senders account.
       return this._storage.get_profile_from_mxid(user_id);
@@ -38,7 +38,7 @@ class DirectMessageHandler {
         throw "No profile found for sender";
       }
       sender = profile;
-      var remote_id = event.state_key.substr(0, event.state_key.indexOf(':')).substr("@_twitter_".length);
+      const remote_id = event.state_key.substr(0, event.state_key.indexOf(':')).substr("@_twitter_".length);
       return this.twitter.profile.get_by_id(remote_id);
     }).then(profile =>{
       if(profile == null) {

--- a/src/handlers/HashtagHandler.js
+++ b/src/handlers/HashtagHandler.js
@@ -71,9 +71,9 @@ class HashtagHandler {
     return {
       creationOpts: {
         visibility: "public",
-        room_alias_name: "_twitter_#"+name,
-        name: "[Twitter] #"+name,
-        topic: "Twitter feed for #"+name,
+        room_alias_name: "_twitter_#" + name,
+        name: "[Twitter] #" + name,
+        topic: "Twitter feed for #" + name,
         initial_state: [
           {
             "type": "m.room.join_rules",

--- a/src/handlers/HashtagHandler.js
+++ b/src/handlers/HashtagHandler.js
@@ -63,7 +63,7 @@ class HashtagHandler {
       return null;
     }
 
-    var remote = new RemoteRoom("hashtag_" + name);
+    const remote = new RemoteRoom("hashtag_" + name);
     remote.set("twitter_type", "hashtag");
     remote.set("twitter_bidirectional", true);
     remote.set("twitter_hashtag", name);

--- a/src/handlers/TimelineHandler.js
+++ b/src/handlers/TimelineHandler.js
@@ -119,7 +119,7 @@ class TimelineHandler {
     const description = (user.description ? user.description : "") + ` | https://twitter.com/${user.screen_name}`;
     const opts = {
       visibility: "public",
-      room_alias_name: "_twitter_@"+alias,
+      room_alias_name: "_twitter_@" + alias,
       name: "[Twitter] " + user.name,
       topic: description,
       invite: [roomOwner],

--- a/src/handlers/TimelineHandler.js
+++ b/src/handlers/TimelineHandler.js
@@ -34,14 +34,14 @@ class TimelineHandler {
   }
 
   processLeave (event, request, context) {
-    var remote = context.rooms.remote;
+    const remote = context.rooms.remote;
     if( remote.data.twitter_type === "user_timeline" && remote.data.twitter_owner === event.sender ) {
       log.info("User %s left room. Leaving", event.sender);
       this.twitter.user_stream.detach(event.sender);
-      var intent = this._bridge.getIntent();
+      const intent = this._bridge.getIntent();
       this.twitter.storage.remove_timeline_room(event.sender);
       intent.leave(event.room_id).then(() =>{
-        var roomstore = this._bridge.getRoomStore();
+        const roomstore = this._bridge.getRoomStore();
         roomstore.removeEntriesByRemoteRoomData(context.rooms.remote.data);
       });
     }
@@ -75,7 +75,7 @@ class TimelineHandler {
   processAliasQuery (alias) {
     //Create the room
     log.info("Looking up " + alias);
-    var tuser;
+    let tuser;
     return this.twitter.get_profile_by_screenname(alias).then((tu) => {
       tuser = tu;
       if (tuser != null) {
@@ -104,20 +104,20 @@ class TimelineHandler {
     The bot will have 100
   */
   _constructTimelineRoom (user, alias, avatar) {
-    var botID = this._bridge.getBot().getUserId();
+    const botID = this._bridge.getBot().getUserId();
 
-    var roomOwner = "@_twitter_" + user.id_str + ":" + this._bridge.opts.domain;
-    var users = {};
+    const roomOwner = "@_twitter_" + user.id_str + ":" + this._bridge.opts.domain;
+    const users = {};
     users[botID] = 100;
     users[roomOwner] = 75;
-    var powers = util.roomPowers(users);
-    var remote = new RemoteRoom("timeline_" + user.id_str);
+    const powers = util.roomPowers(users);
+    const remote = new RemoteRoom("timeline_" + user.id_str);
     remote.set("twitter_type", "timeline");
     remote.set("twitter_user", user.id_str);
     remote.set("twitter_exclude_replies", false);
     remote.set("twitter_bidirectional", true);
-    var description = (user.description ? user.description : "") + ` | https://twitter.com/${user.screen_name}`;
-    var opts = {
+    const description = (user.description ? user.description : "") + ` | https://twitter.com/${user.screen_name}`;
+    const opts = {
       visibility: "public",
       room_alias_name: "_twitter_@"+alias,
       name: "[Twitter] " + user.name,

--- a/src/logging.js
+++ b/src/logging.js
@@ -13,7 +13,7 @@ function init (loggingConfig) {
     timestamp: () => new Date().toISOString().replace(/[TZ]/g, ' '),
     formatter: function (options) {
       return options.timestamp() + options.level + ' ' + (options.message ? options.message : '') +
-        (options.meta && Object.keys(options.meta).length ? '\n\t'+ JSON.stringify(options.meta) : '' );
+        (options.meta && Object.keys(options.meta).length ? '\n\t' + JSON.stringify(options.meta) : '' );
     },
     level: loggingConfig.level,
   }));
@@ -28,7 +28,7 @@ function init (loggingConfig) {
       timestamp: () => new Date().toISOString().replace(/[TZ]/g, ' '),
       formatter: function (options) {
         return options.timestamp() + options.level + ' ' + (options.message ? options.message : '') +
-          (options.meta && Object.keys(options.meta).length ? '\n\t'+ JSON.stringify(options.meta) : '' );
+          (options.meta && Object.keys(options.meta).length ? '\n\t' + JSON.stringify(options.meta) : '' );
       },
       level: loggingConfig.level,
     };

--- a/src/twitter/DirectMessage.js
+++ b/src/twitter/DirectMessage.js
@@ -32,7 +32,7 @@ class DirectMessage {
   }
 
   set_room (sender, recipient, room_id) {
-    var users = [sender.id_str, recipient.id_str].sort().join(';');
+    const users = [sender.id_str, recipient.id_str].sort().join(';');
     return this.twitter.storage.get_dm_room(users).then(room_id =>{
       if(room_id) {
         return this.twitter.storage.remove_dm_room(users);
@@ -40,8 +40,8 @@ class DirectMessage {
       return;
     }).then(() => {
       return this.twitter.storage.add_dm_room(room_id, users).then(() => {
-        var mroom = new Bridge.MatrixRoom(room_id);
-        var rroom = new Bridge.RemoteRoom("dm_"+users);
+        const mroom = new Bridge.MatrixRoom(room_id);
+        const rroom = new Bridge.RemoteRoom("dm_"+users);
         rroom.set("twitter_type", "dm");
         this.twitter.bridge.getRoomStore().linkRooms(mroom, rroom);
         return room_id;
@@ -50,7 +50,7 @@ class DirectMessage {
   }
 
   get_room (sender, recipient) {
-    var users = [sender.id_str, recipient.id_str].sort().join(';');
+    const users = [sender.id_str, recipient.id_str].sort().join(';');
     return this.twitter.storage.get_dm_room(users).then(room_id =>{
       if(room_id) {
         return room_id;
@@ -92,7 +92,7 @@ class DirectMessage {
    */
   send (user_id, room_id, text) {
     //Get the users from the room
-    var users = "";
+    let users = null;
     return this.twitter.storage.get_users_from_dm_room(room_id).then(u =>{
       users = u;
       if(users == null) {
@@ -101,9 +101,9 @@ the DB. This shouldn't happen.`;
       }
       return this.twitter.client_factory.get_client(user_id);
     }).then(client => {
-      var ausers = users.split(';');
+      const ausers = users.split(';');
       ausers.splice(ausers.indexOf(client.profile.id_str), 1);
-      var otheruser = ausers[0];
+      const otheruser = ausers[0];
       log.info(
         "Sending DM from %s(%s) => %s",
         client.profile.id_str,
@@ -122,7 +122,7 @@ the DB. This shouldn't happen.`;
   }
 
   _put_dm_in_room (room_id, msg) {
-    var intent = this.twitter.get_intent(msg.sender.id_str);
+    const intent = this.twitter.get_intent(msg.sender.id_str);
     log.verbose(
       "Recieved DM from %s(%s) => %s(%s)",
       msg.sender.id_str, msg.sender.screen_name,
@@ -144,18 +144,18 @@ the DB. This shouldn't happen.`;
       this.twitter.storage.get_matrixid_from_twitterid(sender.id_str),
       this.twitter.storage.get_matrixid_from_twitterid(recipient.id_str)
     ]).then(user_ids =>{
-      var invitees = new Set([
+      const invitees = new Set([
         "@_twitter_" + sender.id_str + ":" + this.twitter.bridge.opts.domain,
         "@_twitter_" + recipient.id_str + ":" + this.twitter.bridge.opts.domain
       ]);
-      for(var user_id of user_ids) {
+      for(const user_id of user_ids) {
         if(user_id != null) {
           invitees.add(user_id);
         }
       }
       return [...invitees];
     }).then(invitees => {
-      var intent = this.twitter.get_intent(sender.id_str);
+      const intent = this.twitter.get_intent(sender.id_str);
       return intent.createRoom(
         {
           createAsClient: true,

--- a/src/twitter/DirectMessage.js
+++ b/src/twitter/DirectMessage.js
@@ -41,7 +41,7 @@ class DirectMessage {
     }).then(() => {
       return this.twitter.storage.add_dm_room(room_id, users).then(() => {
         const mroom = new Bridge.MatrixRoom(room_id);
-        const rroom = new Bridge.RemoteRoom("dm_"+users);
+        const rroom = new Bridge.RemoteRoom("dm_" + users);
         rroom.set("twitter_type", "dm");
         this.twitter.bridge.getRoomStore().linkRooms(mroom, rroom);
         return room_id;
@@ -162,7 +162,7 @@ the DB. This shouldn't happen.`;
           options: {
             invite: invitees,
             is_direct: true,
-            name: "[Twitter] DM "+sender.screen_name+" : "+recipient.screen_name,
+            name: "[Twitter] DM " + sender.screen_name + " : " + recipient.screen_name,
             visibility: "private",
             initial_state: [
               {

--- a/src/twitter/Status.js
+++ b/src/twitter/Status.js
@@ -96,7 +96,7 @@ class Status {
   _get_room_context (rooms) {
     const context = {screennames: [], hashtags: [], pass: false};
     const promises = [];
-    for(var room of rooms) {
+    for(const room of rooms) {
       const isbi = (room.data.twitter_bidirectional === true) ;
       if(room.data.twitter_type === "user_timeline" && isbi) {
         context.pass = true;
@@ -120,7 +120,7 @@ class Status {
 
   _build_tweets (event, context, profile) {
     //TODO: Get context for REPLYING
-    var content = [];
+    const content = [];
     if(event.content.msgtype === "m.text" || event.content.msgtype === "m.emote") {
       let body = event.content.body;
       if(event.content.msgtype === "m.emote") {

--- a/src/twitter/Status.js
+++ b/src/twitter/Status.js
@@ -129,7 +129,7 @@ class Status {
       let i = 0;
       const sname = "@" + profile.screen_name + " ";
       const tweet_length = TWEET_SIZE - (sname).length;
-      while(i<CONSECUTIVE_TWEET_MAX && body.length > 0) {
+      while(i < CONSECUTIVE_TWEET_MAX && body.length > 0) {
         let tweet;
         if(i === 0) {
           tweet = body.slice(0, TWEET_SIZE);
@@ -137,7 +137,7 @@ class Status {
         else {
           tweet = sname + body.slice(0, tweet_length);
         }
-        body = body.slice(i === 0 ? TWEET_SIZE: tweet_length);
+        body = body.slice(i === 0 ? TWEET_SIZE : tweet_length);
         content.push({status: tweet, in_reply_to_status_id: i > 0 ? "previous" : null});
         i++;
       }
@@ -146,7 +146,7 @@ class Status {
         return Promise.reject(
           {
             "notify": `The tweet was over the limit the bridge supports.
-We support ${CONSECUTIVE_TWEET_MAX*(TWEET_SIZE-(sname.length))} characters (or ${CONSECUTIVE_TWEET_MAX} tweets.) `,
+We support ${CONSECUTIVE_TWEET_MAX * (TWEET_SIZE - (sname.length))} characters (or ${CONSECUTIVE_TWEET_MAX} tweets.) `,
             "error": `Tweet was too large.`
           }
         );

--- a/src/twitter/Timeline.js
+++ b/src/twitter/Timeline.js
@@ -78,8 +78,8 @@ class Timeline {
    * @param  {boolean} opts.is_new Is the room 'new', and we shouldn't do a full poll.
    */
   add_hashtag (hashtag, room_id, opts) {
-    var htag = this._find_hashtag(hashtag);
-    var obj;
+    const htag = this._find_hashtag(hashtag);
+    let obj;
 
     if (this.config.hashtags.enable === false) {
       return;
@@ -125,8 +125,8 @@ class Timeline {
    * @param  {boolean} opts.exclude_replies Should we not fetch replies.
    */
   add_timeline (twitter_id, room_id, opts) {
-    var tline = this._find_timeline(twitter_id);
-    var obj;
+    const tline = this._find_timeline(twitter_id);
+    let obj;
 
     if (this.config.timelines.enable === false) {
       return;
@@ -189,10 +189,10 @@ class Timeline {
 
   _remove_from_queue (isTimeline, id, room_id) {
     const i = isTimeline ? this._find_timeline(id) : this._find_hashtag(id);
-    var queue = isTimeline ? this._timelines : this._hashtags;
+    let queue = isTimeline ? this._timelines : this._hashtags;
     if(i !== -1) {
       if(room_id) {
-        var r = queue[i].room.indexOf(room_id);
+        const r = queue[i].room.indexOf(room_id);
         if (r !== -1) {
           delete queue[i].room[r];
         }
@@ -227,8 +227,8 @@ class Timeline {
       return;
     }
 
-    var tline = this._timelines[this._t];
-    var req = {
+    const tline = this._timelines[this._t];
+    const req = {
       user_id: tline.twitter_id,
       count: TIMELINE_TWEET_FETCH_COUNT,
       exclude_replies: tline.exclude_replies,
@@ -283,8 +283,8 @@ class Timeline {
       return;
     }
 
-    var feed = this._hashtags[this._h];
-    var req = {
+    const feed = this._hashtags[this._h];
+    const req = {
       q: "%23"+feed.hashtag,
       result_type: 'recent',
       count: HASHTAG_TWEET_FETCH_COUNT,

--- a/src/twitter/Timeline.js
+++ b/src/twitter/Timeline.js
@@ -334,7 +334,7 @@ class Timeline {
     // If req.count = 1, the resp will be the initial tweet used to get initial "since"
     if (req.count !== 1) {
       try {
-        yield this.twitter.processor.process_tweets(tline.room, feed, TWEET_REPLY_MAX_DEPTH);
+        yield this.twitter.processor.process_tweets(tline.room, feed, {depth: TWEET_REPLY_MAX_DEPTH} );
       }
       catch(err) {
         log.error("Timeline", "Error whilst processing timeline %s: %s", tline.twitter_id, err);
@@ -393,7 +393,7 @@ class Timeline {
     // If req.count = 1, the resp will be the initial tweet used to get initial "since"
     if (req.count !== 1) {
       try {
-        yield this.twitter.processor.process_tweets(feed.room, results.statuses, 0);
+        yield this.twitter.processor.process_tweets(feed.room, results.statuses, {depth: 0, force_user_id});
       }
       catch(err) {
         log.error("Timeline", "Error whilst processing hashtag feed %s: %s", feed.hashtag, err);

--- a/src/twitter/Timeline.js
+++ b/src/twitter/Timeline.js
@@ -134,7 +134,7 @@ class Timeline {
     else {
       obj = {hashtag, room: new Set() }
       if(opts.is_new) {
-        this._newtags.add("#"+hashtag);
+        this._newtags.add("#" + hashtag);
       }
     }
     obj.room.add(room_id);
@@ -283,7 +283,7 @@ class Timeline {
   }
 
   is_feed_exceeding_user_limit (tweets, timeline = true) {
-    let max = (timeline ? (TIMELINE_POLL_INTERVAL*this._t) : (HASHTAG_POLL_INTERVAL*this._h))/60000;
+    let max = (timeline ? (TIMELINE_POLL_INTERVAL * this._t) : (HASHTAG_POLL_INTERVAL * this._h)) / 60000;
     max = Math.max(max * NEW_PROFILE_THRESHOLD_MIN, 1)
     if ((timeline ? this.config.timelines : this.config.hashtags).single_account_fallback === true) {
       const user_ids = new Set(tweets.map((tweet) => {tweet.id_str})).size;
@@ -322,7 +322,7 @@ class Timeline {
 
   *_process_feed (isTimeline, feed) {
     const client = yield this.twitter.client_factory.get_client();
-    const sinceId = isTimeline ? "@"+feed.twitter_id : feed.hashtag;
+    const sinceId = isTimeline ? "@" + feed.twitter_id : feed.hashtag;
     const getPath = isTimeline ? 'statuses/user_timeline' : 'search/tweets'
     if(this.is_room_excluded(feed.room)) {
       log.info("Timeline", `${feed.hashtag} is ignored because the room(s) contains no real members`);
@@ -340,11 +340,11 @@ class Timeline {
         this._newtags.delete(feed.twitter_id);
       }
     } else {
-      req.q = "%23"+feed.hashtag;
+      req.q = "%23" + feed.hashtag;
       req.result_type = 'recent';
-      if(this._newtags.has("#"+feed.hashtag)) {
+      if(this._newtags.has("#" + feed.hashtag)) {
         req.count = 1;
-        this._newtags.delete("#"+feed.hashtag);
+        this._newtags.delete("#" + feed.hashtag);
       }
     }
     const since = yield this.twitter.storage.get_since(sinceId);
@@ -371,12 +371,10 @@ class Timeline {
     }
     this.twitter.storage.set_since(sinceId, results[0].id_str);
     const shouldForceUserId = this.is_feed_exceeding_user_limit(results, isTimeline);
-    let force_user_id;
+    let force_user_id = null;
     if(shouldForceUserId) {
       log.verbose("Timeline", `Forcing single user mode for ${feed.hashtag}`);
       force_user_id = shouldForceUserId ? `_twitter_@` + feed.twitter_id : `_twitter_#` + feed.hashtag;
-    } else {
-      force_user_id = null;
     }
     // If req.count = 1, the resp will be the initial tweet used to get initial "since"
     if (req.count !== 1) {

--- a/src/twitter/Timeline.js
+++ b/src/twitter/Timeline.js
@@ -1,10 +1,9 @@
 const log      = require('../logging.js');
 const Promise  = require('bluebird');
-const Util  = require('../util.js');
 
-const TIMELINE_POLL_INTERVAL = 3010; //Twitter allows 300 calls per 15 minute (We add 10 milliseconds for a little safety).
-const HASHTAG_POLL_INTERVAL = 2010; //Twitter allows 450 calls per 15 minute (We add 10 milliseconds for a little safety).
-const EMPTY_ROOM_INTERVAL = 30000;
+const TIMELINE_POLL_INTERVAL_MS = 3010; //Twitter allows 300 calls per 15 minute (We add 10 milliseconds for a little safety).
+const HASHTAG_POLL_INTERVAL_MS = 2010; //Twitter allows 450 calls per 15 minute (We add 10 milliseconds for a little safety).
+const EMPTY_ROOM_INTERVAL_MS = 30000;
 const TIMELINE_TWEET_FETCH_COUNT = 100;
 const HASHTAG_TWEET_FETCH_COUNT = 100;
 const TWEET_REPLY_MAX_DEPTH = 0;
@@ -26,8 +25,8 @@ class Timeline {
     this._hashtags = [] // {hashtag:string, room:[string]}
     this._newtags = new Set();
     this._empty_rooms = new Set();
-    this._h = -1;
-    this._t = -1;
+    this._hashtagIndex = -1;
+    this._timelineIndex = -1;
     this.config = {
       timelines: cfg_timelines,
       hashtags: cfg_hashtags
@@ -35,14 +34,14 @@ class Timeline {
   }
 
   /**
-   * Do a sync every EMPTY_ROOM_INTERVAL to get the list of members to a room.
+   * Do a sync every EMPTY_ROOM_INTERVAL_MS to get the list of members to a room.
    * If a room has no 'real' members then drop/ignore it.
    * If a room has 'real' members then keep/ignore it.
    */
   start_empty_room_checker () {
     this._empty_intervalID = setInterval(() => {
       Promise.coroutine(this._check_empty_rooms.bind(this))()
-    }, EMPTY_ROOM_INTERVAL);
+    }, EMPTY_ROOM_INTERVAL_MS);
   }
 
   stop_empty_room_checker () {
@@ -50,7 +49,7 @@ class Timeline {
       clearInterval(this._empty_intervalID);
       this._empty_intervalID = null;
     } else {
-      throw Error("Timer not started");
+      throw Error("Empty Room timer not started");
     }
   }
 
@@ -59,8 +58,8 @@ class Timeline {
    */
   start_timeline () {
     this._t_intervalID = setInterval(() => {
-      this._process_timeline();
-    }, TIMELINE_POLL_INTERVAL);
+      Promise.coroutine(this._process_feed.bind(this))(true);
+    }, TIMELINE_POLL_INTERVAL_MS);
   }
 
   /**
@@ -71,7 +70,7 @@ class Timeline {
       clearInterval(this._t_intervalID);
       this._t_intervalID = null;
     } else {
-      throw Error("Timer not started");
+      throw Error("Timeline timer not started");
     }
   }
 
@@ -80,8 +79,8 @@ class Timeline {
    */
   start_hashtag () {
     this._h_intervalID = setInterval(() => {
-      this._process_hashtag();
-    }, HASHTAG_POLL_INTERVAL);
+      Promise.coroutine(this._process_feed.bind(this))(false);
+    }, HASHTAG_POLL_INTERVAL_MS);
   }
 
   /**
@@ -92,7 +91,7 @@ class Timeline {
       clearInterval(this._h_intervalID);
       this._h_intervalID = null;
     } else {
-      throw Error("Timer not started");
+      throw Error("Hashtag timer not started");
     }
   }
 
@@ -110,14 +109,8 @@ class Timeline {
     if (this.config.hashtags.enable === false) {
       return false;
     }
-    if (!Util.isRoomId(room_id)) {
-      throw Error("Not a valid room_id");
-    }
-    if(!Util.isTwitterHashtag(hashtag)) {
-      throw Error("Not a valid hashtag");
-    }
-    const htag = this._find_hashtag(hashtag);
-    let obj;
+    const hashtagIndex = this._find_hashtag(hashtag);
+    let hashtagObj;
 
     if(opts === undefined) {
       opts = {};
@@ -127,21 +120,21 @@ class Timeline {
       opts.is_new = false;
     }
 
-    if(htag !== -1) {
-      obj = this._hashtags[htag]
+    if(hashtagIndex !== -1) {
+      hashtagObj = this._hashtags[hashtagIndex]
     }
     else {
-      obj = {hashtag, room: new Set() }
+      hashtagObj = {hashtag, room: new Set() }
       if(opts.is_new) {
         this._newtags.add("#" + hashtag);
       }
     }
-    obj.room.add(room_id);
-    if(htag !== -1) {
-      this._hashtags[htag] = obj;
+    hashtagObj.room.add(room_id);
+    if(hashtagIndex !== -1) {
+      this._hashtags[hashtagIndex] = hashtagObj;
     }
     else {
-      this._hashtags.push(obj);
+      this._hashtags.push(hashtagObj);
     }
     log.info("Added Hashtag: %s", hashtag);
     return true;
@@ -162,11 +155,8 @@ class Timeline {
     if (this.config.timelines.enable === false) {
       return false;
     }
-    if (!Util.isRoomId(room_id)) {
-      throw Error("Not a valid room_id");
-    }
-    const tline = this._find_timeline(twitter_id);
-    let obj;
+    const timelineIndex = this._find_timeline(twitter_id);
+    let timeline;
 
     if(opts === undefined) {
       opts = {};
@@ -184,25 +174,25 @@ class Timeline {
       opts.high_traffic_mode = false;
     }
 
-    if(tline !== -1) {
-      obj = this._timelines[tline]
+    if(timelineIndex !== -1) {
+      timeline = this._timelines[timelineIndex]
     }
     else {
-      obj = {
+      timeline = {
         twitter_id,
         room: new Set(),
-        exclude_replies: opts.exclude_replies,
+        exclude_replies: opts.exclude_replies
       }
       if(opts.is_new) {
         this._newtags.add(twitter_id);
       }
     }
-    obj.room.add(room_id);
-    if(tline !== -1) {
-      this._timelines[tline] = obj;
+    timeline.room.add(room_id);
+    if(timelineIndex !== -1) {
+      this._timelines[timelineIndex] = timeline;
     }
     else {
-      this._timelines.push(obj);
+      this._timelines.push(timeline);
     }
     log.info("Added Timeline: %s", twitter_id);
     return true;
@@ -212,12 +202,12 @@ class Timeline {
    * remove_timeline - Remove a timeline from being
    * processed.
    *
-   * @param  {string} twitter_id The twitter id of the timeline to remove.
-   * @param  {string} [room_id] If specified, only remove from this room.
+   * @param  {string} twitterId The twitter id of the timeline to remove.
+   * @param  {string} [roomId] If specified, only remove from this room.
    * @return {boolean} Was the operation successful.
    */
-  remove_timeline (twitter_id, room_id) {
-    return this._remove_from_queue(true, twitter_id, room_id);
+  remove_timeline (twitterId, roomId) {
+    return this._removeFromQueue(true, twitterId, roomId);
   }
 
   /**
@@ -225,50 +215,48 @@ class Timeline {
    * processed.
    *
    * @param  {string} hashtag The hashtag to remove. (without the #)
-   * @param  {string} [room_id] If specified, only remove from this room.
+   * @param  {string} [roomId] If specified, only remove from this room.
    * @return {boolean} Was the operation successful.
    */
-  remove_hashtag (hashtag, room_id) {
-    return this._remove_from_queue(false, hashtag, room_id);
+  remove_hashtag (hashtag, roomId) {
+    return this._removeFromQueue(false, hashtag, roomId);
   }
 
-  _remove_from_queue (isTimeline, id, room_id) {
+  _removeFromQueue (isTimeline, id, roomId) {
     // Get the index of the item and it's associated queue.
     const i = isTimeline ? this._find_timeline(id) : this._find_hashtag(id);
     const queue = isTimeline ? this._timelines : this._hashtags;
-    const removeSingle = room_id !== undefined;
-    if(i !== -1) {
-      if(removeSingle) {
-        if (queue[i].room.has(room_id)) {
-          queue[i].room.delete(room_id);
-        }
-        else{
-          log.warn("Tried to remove %s for %s but it didn't exist", room_id, id);
-          return true; // Well, the room doesn't exist
-        }
-      }
-      else {
-        // Remove the whole timeline.
-        queue[i].room.clear();
-      }
-
-      // Are any rooms being processed at this point. Remove if not.
-      if(queue[i].room.size === 0) {
-        queue.splice(i, 1);
-      }
-
-      if(isTimeline) {
-        this._timelines = queue;
-      }
-      else{
-        this._hashtags = queue;
-      }
-      return true;
-    }
-    else {
+    const removeSingle = roomId !== undefined;
+    if(i === -1) {
       log.warn("Tried to remove %s but it isn't queued.", id);
       return false;
     }
+    if(removeSingle) {
+      if (queue[i].room.has(roomId)) {
+        queue[i].room.delete(roomId);
+      }
+      else{
+        log.warn("Tried to remove %s for %s but it didn't exist", roomId, id);
+        return true; // Well, the room doesn't exist
+      }
+    }
+    else {
+      // Remove the whole timeline.
+      queue[i].room.clear();
+    }
+
+    // Are any rooms being processed at this point. Remove if not.
+    if(queue[i].room.size === 0) {
+      queue.splice(i, 1);
+    }
+
+    if(isTimeline) {
+      this._timelines = queue;
+    }
+    else{
+      this._hashtags = queue;
+    }
+    return true
   }
 
   is_room_excluded (rooms) {
@@ -292,49 +280,45 @@ class Timeline {
     // Number of new profiles that we can accept in this timespan.
     const maxNProfiles = Math.ceil((currentPollInterval / 60000) * NEW_PROFILE_THRESHOLD_MIN);
     const userIds = new Set(tweets.map((tweet) => {tweet.id_str})).size;
-    log.verbose(`is_feed_exceeding_user_limit: ${userIds} > ${maxNProfiles}`);
     return userIds > maxNProfiles;
   }
 
-  _process_timeline () {
-    if (this._timelines.length === 0) {
-      return Promise.resolve();
-    }
-    // Rotate to the next timeline.
-    this._t++;
-    if(this._t >= this._timelines.length) {
-      this._t = 0;
-    }
-
-    const tline = this._timelines[this._t];
-    return Promise.coroutine(this._process_feed.bind(this))(true, tline);
-  }
-
-  _process_hashtag () {
-    if (this._hashtags.length === 0) {
-      return Promise.resolve();
-    }
-    this._h++;
-    if(this._h >= this._hashtags.length) {
-      this._h = 0;
-    }
-
-    const feed = this._hashtags[this._h];
-    return Promise.coroutine(this._process_feed.bind(this))(false, feed);
-  }
-
-  *_process_feed (isTimeline, feed) {
-    const client = yield this.twitter.client_factory.get_client();
-    const sinceId = isTimeline ? "@" + feed.twitter_id : feed.hashtag;
-    const getPath = isTimeline ? 'statuses/user_timeline' : 'search/tweets'
-    if(this.is_room_excluded(feed.room)) {
-      log.info("Timeline", `${feed.hashtag} is ignored because the room(s) contains no real members`);
-      return;
-    }
+  * _process_feed (isTimeline) {
     const req = {
       count: isTimeline ? TIMELINE_TWEET_FETCH_COUNT : HASHTAG_TWEET_FETCH_COUNT,
       tweet_mode: "extended" // https://github.com/Half-Shot/matrix-appservice-twitter/issues/31
     };
+    const getPath = isTimeline ? 'statuses/user_timeline' : 'search/tweets';
+
+    let feed;
+    if(isTimeline) {
+      if (this._timelines.length === 0) {
+        return;
+      }
+      // Rotate to the next timeline.
+      this._timelineIndex++;
+      if(this._timelineIndex >= this._timelines.length) {
+        this._timelineIndex = 0;
+      }
+      feed = this._timelines[this._timelineIndex];
+    }
+    else {
+      if (this._hashtags.length === 0) {
+        return;
+      }
+      this._hashtagIndex++;
+      if(this._hashtagIndex >= this._hashtags.length) {
+        this._hashtagIndex = 0;
+      }
+      feed = this._hashtags[this._hashtagIndex];
+    }
+
+    const client = yield this.twitter.client_factory.get_client();
+    const sinceId = isTimeline ? "@" + feed.twitter_id : feed.hashtag;
+    if(this.is_room_excluded(feed.room)) {
+      log.info("Timeline", `${sinceId} is ignored because the room(s) contains no real members`);
+      return;
+    }
     if (isTimeline) {
       req.user_id = feed.twitter_id;
       req.exclude_replies = feed.exclude_replies;
@@ -374,15 +358,15 @@ class Timeline {
     }
     this.twitter.storage.set_since(sinceId, results[0].id_str);
     const shouldForceUserId = this.is_feed_exceeding_user_limit(results, isTimeline);
-    let force_user_id = null;
+    let forceUserId = null;
     if(shouldForceUserId) {
-      log.verbose("Timeline", `Forcing single user mode for ${feed.hashtag}`);
-      force_user_id = shouldForceUserId ? `_twitter_@` + feed.twitter_id : `_twitter_#` + feed.hashtag;
+      log.verbose("Timeline", `Forcing single user mode for ${sinceId}`);
+      forceUserId = shouldForceUserId ? `_twitter_@` + feed.twitter_id : `_twitter_#` + feed.hashtag;
     }
     // If req.count = 1, the resp will be the initial tweet used to get initial "since"
     if (req.count !== 1) {
       try {
-        return this.twitter.processor.process_tweets(feed.room, results, {depth: TWEET_REPLY_MAX_DEPTH, force_user_id});
+        return this.twitter.processor.process_tweets(feed.room, results, {depth: TWEET_REPLY_MAX_DEPTH, forceUserId});
       }
       catch(err) {
         log.error("Timeline", "Error whilst processing %s: %s", sinceId, err);

--- a/src/twitter/Timeline.js
+++ b/src/twitter/Timeline.js
@@ -406,10 +406,8 @@ class Timeline {
     for (const room in memberLists) {
       if (memberLists[room].realJoinedUsers.length === 0) {
         log.silly("Timeline", "%s has no real users", room);
-        console.log("A:"+room);
         this._empty_rooms.add(room);
       } else {
-        console.log("D:"+room);
         this._empty_rooms.delete(room);
       }
     }

--- a/src/twitter/Timeline.js
+++ b/src/twitter/Timeline.js
@@ -55,7 +55,7 @@ class Timeline {
    */
   start_timeline () {
     this._t_intervalID = setInterval(() => {
-      Promise.coroutine(this._process_timeline.bind(this))()
+      Promise.coroutine(this._process_timeline.bind(this))();
     }, TIMELINE_POLL_INTERVAL);
   }
 
@@ -74,7 +74,7 @@ class Timeline {
    */
   start_hashtag () {
     this._h_intervalID = setInterval(() => {
-      Promise.coroutine(this._process_hashtags.bind(this))()
+      Promise.coroutine(this._process_hashtags.bind(this))();
     }, HASHTAG_POLL_INTERVAL);
   }
 

--- a/src/twitter/Timeline.js
+++ b/src/twitter/Timeline.js
@@ -1,7 +1,9 @@
 const log      = require('../logging.js');
+const Promise  = require('bluebird');
 
 const TIMELINE_POLL_INTERVAL = 3010; //Twitter allows 300 calls per 15 minute (We add 10 milliseconds for a little safety).
 const HASHTAG_POLL_INTERVAL = 2010; //Twitter allows 450 calls per 15 minute (We add 10 milliseconds for a little safety).
+const EMPTY_ROOM_INTERVAL = 5000;
 const TIMELINE_TWEET_FETCH_COUNT = 100;
 const HASHTAG_TWEET_FETCH_COUNT = 100;
 const TWEET_REPLY_MAX_DEPTH = 0;
@@ -17,11 +19,13 @@ class Timeline {
     this.twitter = twitter;
     this._t_intervalID = null;
     this._h_intervalID = null;
+    this._empty_intervalID = null;
     this._timelines = [] // {twitter_id:string, room:[string]}
     this._hashtags = [] // {hashtag:string, room:[string]}
     this._newtags = new Set();
-    this._h = 0;
-    this._t = 0;
+    this._empty_rooms = [];
+    this._h = -1;
+    this._t = -1;
     this.config = {
       timelines: cfg_timelines,
       hashtags: cfg_hashtags
@@ -29,16 +33,30 @@ class Timeline {
   }
 
   /**
-   * Do a sync every 5 minutes to get the list of members to a room.
+   * Do a sync every EMPTY_ROOM_INTERVAL to get the list of members to a room.
    * If a room has no 'real' members then drop/ignore it.
    * If a room has 'real' members then keep/ignore it.
    */
+  start_empty_room_checker () {
+    this._t_intervalID = setInterval(() => {
+      Promise.coroutine(this._check_empty_rooms.bind(this))()
+    }, EMPTY_ROOM_INTERVAL);
+  }
+
+  stop_empty_room_checker () {
+    if (this._empty_intervalID) {
+      clearInterval(this._empty_intervalID);
+      this._empty_intervalID = null;
+    }
+  }
 
   /**
    * Start the timeline timer so that timelines will be processed in turn.
    */
   start_timeline () {
-    this._t_intervalID = setInterval(() => {this._process_timeline();}, TIMELINE_POLL_INTERVAL);
+    this._t_intervalID = setInterval(() => {
+      Promise.coroutine(this._process_timeline.bind(this))()
+    }, TIMELINE_POLL_INTERVAL);
   }
 
   /**
@@ -55,7 +73,9 @@ class Timeline {
    * Start the hashtag timer so that hashtags are processed in turn.
    */
   start_hashtag () {
-    this._h_intervalID = setInterval(() => {this._process_hashtags();}, HASHTAG_POLL_INTERVAL);
+    this._h_intervalID = setInterval(() => {
+      Promise.coroutine(this._process_hashtags.bind(this))()
+    }, HASHTAG_POLL_INTERVAL);
   }
 
   /**
@@ -118,11 +138,15 @@ class Timeline {
    * Add a Twitters user's timeline to the timeline processor. Tweets will be
    * automatically send to the given room.
    *
+   * HTM* - Use a single account to send tweets, avoiding large numbers of join
+   * events. This is enabled automatically unless disabled via config
+   *
    * @param  {string} twitter_id The twitter ID of a timeline.
    * @param  {string} room_id The room_id to insert tweets into.
    * @param  {object} opts Options
    * @param  {boolean} opts.is_new Is the room 'new', and we shouldn't do a full poll.
    * @param  {boolean} opts.exclude_replies Should we not fetch replies.
+   * @param  {boolean} opts.high_traffic_mode Enable high traffic mode on the timeline*.
    */
   add_timeline (twitter_id, room_id, opts) {
     const tline = this._find_timeline(twitter_id);
@@ -144,11 +168,15 @@ class Timeline {
       opts.exclude_replies = false;
     }
 
+    if(opts.high_traffic_mode === undefined) {
+      opts.high_traffic_mode = false;
+    }
+
     if(tline !== -1) {
       obj = this._timelines[tline]
     }
     else {
-      obj = {twitter_id, room: [], exclude_replies: opts.exclude_replies }
+      obj = {twitter_id, room: [], exclude_replies: opts.exclude_replies, high_traffic_mode: opts.high_traffic_mode }
       if(opts.is_new) {
         this._newtags.add(twitter_id);
       }
@@ -222,12 +250,26 @@ class Timeline {
     }
   }
 
-  _process_timeline () {
+  * _process_timeline () {
     if (this._timelines.length === 0) {
       return;
     }
+    this._t++;
+    if(this._t >= this._timelines.length) {
+      this._t = 0;
+    }
 
     const tline = this._timelines[this._t];
+    if (!this.config.timelines.poll_if_empty) {
+      if (tline.room.every((roomId) =>{
+        this._empty_rooms.includes(roomId);
+      })) {
+        log.info("Timeline", "Skipping %s because no real users are using it.", tline.twitter_id);
+        return;
+      }
+    }
+
+    const client = yield this.twitter.client_factory.get_client();
     const req = {
       user_id: tline.twitter_id,
       count: TIMELINE_TWEET_FETCH_COUNT,
@@ -240,50 +282,59 @@ class Timeline {
       this._newtags.delete(req.user_id);
     }
 
-    this.twitter.storage.get_since("@"+tline.twitter_id).then((since) => {
-      log.silly("Polling %s, since value: %s", "@"+tline.twitter_id, since);
-      if (since) {
-        req.since_id = since;
+    const since = yield this.twitter.storage.get_since("@"+tline.twitter_id);
+    if (since) {
+      req.since_id = since;
+    }
+    let feed;
+    try {
+      feed = yield client.getAsync('statuses/user_timeline', req);
+    }
+    catch (error) {
+      log.error("Timeline", "_process_timeline: GET /statuses/user_timeline returned: %s", error.code);
+      return;
+    }
+    if (feed.length === 0) {
+      return;
+    }
+    else if(feed.length === TIMELINE_TWEET_FETCH_COUNT) {
+      log.info("Timeline", "Poll request hit count limit. Request likely incomplete.");
+    }
+    const s = feed[0].id_str;
+    this.twitter.storage.set_since("@"+tline.twitter_id, s);
+    // If req.count = 1, the resp will be the initial tweet used to get initial "since"
+    if (req.count !== 1) {
+      try {
+        yield this.twitter.processor.process_tweets(tline.room, feed, TWEET_REPLY_MAX_DEPTH);
       }
-      return this.twitter.client_factory.get_client();
-    }).then((client)=>{
-      return client.get('statuses/user_timeline', req).catch((error) =>{
-        log.error("Timeline", "_process_timeline: GET /statuses/user_timeline returned: %s", error.code);
-      });
-    }).then((feed) => {
-      if (feed.length === 0) {
-        return;
+      catch(err) {
+        log.error("Timeline", "Error whilst processing timeline %s: %s", tline.twitter_id, err);
       }
-      else if(feed.length === TIMELINE_TWEET_FETCH_COUNT) {
-        log.info("Timeline poll request hit count limit. Request likely incomplete.");
-      }
-      const s = feed[0].id_str;
-
-      log.silly("Timeline", "Storing since: %s", s);
-      this.twitter.storage.set_since("@"+tline.twitter_id, s);
-
-      // If req.count = 1, the resp will be the initial tweet used to get initial "since"
-      if (req.count !== 1) {
-        this.twitter.processor.process_tweets(tline.room, feed, TWEET_REPLY_MAX_DEPTH);
-      }
-
-      tline.hasProcessedTweets = true;
-    }).catch((err) => {
-      log.error("Timeline", "Error whilst processing timeline %s: %s", tline.twitter_id, err);
-    });
-
-    this._t++;
-    if(this._t >= this._timelines.length) {
-      this._t = 0;
     }
   }
 
-  _process_hashtags () {
-    if (this._hashtags.length < 1) {
+  * _process_hashtags () {
+    if (this._hashtags.length === 0) {
       return;
     }
+    this._h++;
+    if(this._h >= this._hashtags.length) {
+      this._h = 0;
+    }
 
+    const client = yield this.twitter.client_factory.get_client();
     const feed = this._hashtags[this._h];
+
+
+    if (!this.config.hashtags.poll_if_empty) {
+      if (feed.room.every((roomId) =>{
+        return this._empty_rooms.includes(roomId);
+      })) {
+        log.verbose("Timeline", "Skipping #%s because no real users are using it.", feed.hashtag);
+        return;
+      }
+    }
+    
     const req = {
       q: "%23"+feed.hashtag,
       result_type: 'recent',
@@ -296,35 +347,49 @@ class Timeline {
       this._newtags.delete("#"+feed.hashtag);
     }
 
-    this.twitter.storage.get_since(feed.hashtag).then((since) => {
-      log.silly("Polling %s, since value: %s", feed.hashtag, since);
-      if (since) {
-        req.since_id = since;
-      }
-      return this.twitter.client_factory.get_client();
-    }).then((client)=>{
-      return client.get('search/tweets', req);
-    }).then((results) => {
-      if (results.statuses.length === 0) {
-        return;
-      }
-      else{
-        if(results.statuses.length === HASHTAG_TWEET_FETCH_COUNT) {
-          log.info("Hashtag poll request hit count limit. Request likely incomplete.");
-        }
-      }
-      const s = results.statuses[0].id_str;
-      this.twitter.storage.set_since(feed.hashtag, s);
-      log.silly("Storing since: %s", s);
-      this.twitter.processor.process_tweets(feed.room, results.statuses, 0);
-    }).catch((error) => {
-      log.error("_process_hashtag_feed: GET /search/tweets returned: %s", error);
-    });
-
-    this._h++;
-    if(this._h >= this._hashtags.length) {
-      this._h = 0;
+    const since = yield this.twitter.storage.get_since(feed.hashtag);
+    if (since) {
+      req.since_id = since;
     }
+    let results;
+    try {
+      results = yield client.getAsync('search/tweets', req);
+    }
+    catch (error) {
+      log.error("Timeline", "_process_hashtags: GET /search/tweets returned: %s", error.code);
+      return;
+    }
+    if (results.statuses.length === 0) {
+      return;
+    }
+    else if(results.statuses.length === HASHTAG_TWEET_FETCH_COUNT) {
+      log.info("Timeline", "Poll request hit count limit. Request likely incomplete.");
+    }
+    const s = results.statuses[0].id_str;
+    this.twitter.storage.set_since(feed.hashtag, s);
+    // If req.count = 1, the resp will be the initial tweet used to get initial "since"
+    if (req.count !== 1) {
+      try {
+        yield this.twitter.processor.process_tweets(feed.room, results.statuses, 0);
+      }
+      catch(err) {
+        log.error("Timeline", "Error whilst processing hashtag feed %s: %s", feed.hashtag, err);
+      }
+    }
+  }
+
+  * _check_empty_rooms () {
+    const bot = this.twitter.bridge.getBot();
+    const memberLists = yield bot.getMemberLists();
+    const empty_room_list = [];
+    for (const room in memberLists) {
+      if (memberLists[room].realJoinedUsers.length === 0) {
+        log.silly("Timeline", "%s has no real users", room);
+        empty_room_list.push(room);
+      }
+    }
+    this._empty_rooms = empty_room_list;
+    return false;
   }
 
   _find_timeline (twitter_id) {

--- a/src/twitter/Timeline.js
+++ b/src/twitter/Timeline.js
@@ -1,7 +1,9 @@
 const log      = require('../logging.js');
+const Promise  = require('bluebird');
 
 const TIMELINE_POLL_INTERVAL = 3010; //Twitter allows 300 calls per 15 minute (We add 10 milliseconds for a little safety).
 const HASHTAG_POLL_INTERVAL = 2010; //Twitter allows 450 calls per 15 minute (We add 10 milliseconds for a little safety).
+const EMPTY_ROOM_INTERVAL = 5000;
 const TIMELINE_TWEET_FETCH_COUNT = 100;
 const HASHTAG_TWEET_FETCH_COUNT = 100;
 const TWEET_REPLY_MAX_DEPTH = 0;
@@ -17,11 +19,13 @@ class Timeline {
     this.twitter = twitter;
     this._t_intervalID = null;
     this._h_intervalID = null;
+    this._empty_intervalID = null;
     this._timelines = [] // {twitter_id:string, room:[string]}
     this._hashtags = [] // {hashtag:string, room:[string]}
     this._newtags = new Set();
-    this._h = 0;
-    this._t = 0;
+    this._empty_rooms = [];
+    this._h = -1;
+    this._t = -1;
     this.config = {
       timelines: cfg_timelines,
       hashtags: cfg_hashtags
@@ -29,16 +33,30 @@ class Timeline {
   }
 
   /**
-   * Do a sync every 5 minutes to get the list of members to a room.
+   * Do a sync every EMPTY_ROOM_INTERVAL to get the list of members to a room.
    * If a room has no 'real' members then drop/ignore it.
    * If a room has 'real' members then keep/ignore it.
    */
+  start_empty_room_checker () {
+    this._t_intervalID = setInterval(() => {
+      Promise.coroutine(this._check_empty_rooms.bind(this))()
+    }, EMPTY_ROOM_INTERVAL);
+  }
+
+  stop_empty_room_checker () {
+    if (this._empty_intervalID) {
+      clearInterval(this._empty_intervalID);
+      this._empty_intervalID = null;
+    }
+  }
 
   /**
    * Start the timeline timer so that timelines will be processed in turn.
    */
   start_timeline () {
-    this._t_intervalID = setInterval(() => {this._process_timeline();}, TIMELINE_POLL_INTERVAL);
+    this._t_intervalID = setInterval(() => {
+      Promise.coroutine(this._process_timeline.bind(this))()
+    }, TIMELINE_POLL_INTERVAL);
   }
 
   /**
@@ -55,7 +73,9 @@ class Timeline {
    * Start the hashtag timer so that hashtags are processed in turn.
    */
   start_hashtag () {
-    this._h_intervalID = setInterval(() => {this._process_hashtags();}, HASHTAG_POLL_INTERVAL);
+    this._h_intervalID = setInterval(() => {
+      Promise.coroutine(this._process_hashtags.bind(this))()
+    }, HASHTAG_POLL_INTERVAL);
   }
 
   /**
@@ -118,11 +138,15 @@ class Timeline {
    * Add a Twitters user's timeline to the timeline processor. Tweets will be
    * automatically send to the given room.
    *
+   * HTM* - Use a single account to send tweets, avoiding large numbers of join
+   * events. This is enabled automatically unless disabled via config
+   *
    * @param  {string} twitter_id The twitter ID of a timeline.
    * @param  {string} room_id The room_id to insert tweets into.
    * @param  {object} opts Options
    * @param  {boolean} opts.is_new Is the room 'new', and we shouldn't do a full poll.
    * @param  {boolean} opts.exclude_replies Should we not fetch replies.
+   * @param  {boolean} opts.high_traffic_mode Enable high traffic mode on the timeline*.
    */
   add_timeline (twitter_id, room_id, opts) {
     var tline = this._find_timeline(twitter_id);
@@ -144,11 +168,15 @@ class Timeline {
       opts.exclude_replies = false;
     }
 
+    if(opts.high_traffic_mode === undefined) {
+      opts.high_traffic_mode = false;
+    }
+
     if(tline !== -1) {
       obj = this._timelines[tline]
     }
     else {
-      obj = {twitter_id, room: [], exclude_replies: opts.exclude_replies }
+      obj = {twitter_id, room: [], exclude_replies: opts.exclude_replies, high_traffic_mode: opts.high_traffic_mode }
       if(opts.is_new) {
         this._newtags.add(twitter_id);
       }
@@ -222,13 +250,27 @@ class Timeline {
     }
   }
 
-  _process_timeline () {
+  * _process_timeline () {
     if (this._timelines.length === 0) {
       return;
     }
+    this._t++;
+    if(this._t >= this._timelines.length) {
+      this._t = 0;
+    }
 
-    var tline = this._timelines[this._t];
-    var req = {
+    const tline = this._timelines[this._t];
+    if (!this.config.timelines.poll_if_empty) {
+      if (tline.room.every((roomId) =>{
+        this._empty_rooms.includes(roomId);
+      })) {
+        log.info("Timeline", "Skipping %s because no real users are using it.", tline.twitter_id);
+        return;
+      }
+    }
+
+    const client = yield this.twitter.client_factory.get_client();
+    const req = {
       user_id: tline.twitter_id,
       count: TIMELINE_TWEET_FETCH_COUNT,
       exclude_replies: tline.exclude_replies,
@@ -240,50 +282,59 @@ class Timeline {
       this._newtags.delete(req.user_id);
     }
 
-    this.twitter.storage.get_since("@"+tline.twitter_id).then((since) => {
-      log.silly("Polling %s, since value: %s", "@"+tline.twitter_id, since);
-      if (since) {
-        req.since_id = since;
+    const since = yield this.twitter.storage.get_since("@"+tline.twitter_id);
+    if (since) {
+      req.since_id = since;
+    }
+    let feed;
+    try {
+      feed = yield client.getAsync('statuses/user_timeline', req);
+    }
+    catch (error) {
+      log.error("Timeline", "_process_timeline: GET /statuses/user_timeline returned: %s", error.code);
+      return;
+    }
+    if (feed.length === 0) {
+      return;
+    }
+    else if(feed.length === TIMELINE_TWEET_FETCH_COUNT) {
+      log.info("Timeline", "Poll request hit count limit. Request likely incomplete.");
+    }
+    const s = feed[0].id_str;
+    this.twitter.storage.set_since("@"+tline.twitter_id, s);
+    // If req.count = 1, the resp will be the initial tweet used to get initial "since"
+    if (req.count !== 1) {
+      try {
+        yield this.twitter.processor.process_tweets(tline.room, feed, TWEET_REPLY_MAX_DEPTH);
       }
-      return this.twitter.client_factory.get_client();
-    }).then((client)=>{
-      return client.getAsync('statuses/user_timeline', req).catch((error) =>{
-        log.error("Timeline", "_process_timeline: GET /statuses/user_timeline returned: %s", error.code);
-      });
-    }).then((feed) => {
-      if (feed.length === 0) {
-        return;
+      catch(err) {
+        log.error("Timeline", "Error whilst processing timeline %s: %s", tline.twitter_id, err);
       }
-      else if(feed.length === TIMELINE_TWEET_FETCH_COUNT) {
-        log.info("Timeline poll request hit count limit. Request likely incomplete.");
-      }
-      const s = feed[0].id_str;
-
-      log.silly("Timeline", "Storing since: %s", s);
-      this.twitter.storage.set_since("@"+tline.twitter_id, s);
-
-      // If req.count = 1, the resp will be the initial tweet used to get initial "since"
-      if (req.count !== 1) {
-        this.twitter.processor.process_tweets(tline.room, feed, TWEET_REPLY_MAX_DEPTH);
-      }
-
-      tline.hasProcessedTweets = true;
-    }).catch((err) => {
-      log.error("Timeline", "Error whilst processing timeline %s: %s", tline.twitter_id, err);
-    });
-
-    this._t++;
-    if(this._t >= this._timelines.length) {
-      this._t = 0;
     }
   }
 
-  _process_hashtags () {
-    if (this._hashtags.length < 1) {
+  * _process_hashtags () {
+    if (this._hashtags.length === 0) {
       return;
     }
+    this._h++;
+    if(this._h >= this._hashtags.length) {
+      this._h = 0;
+    }
 
-    var feed = this._hashtags[this._h];
+    const client = yield this.twitter.client_factory.get_client();
+    const feed = this._hashtags[this._h];
+
+
+    if (!this.config.hashtags.poll_if_empty) {
+      if (feed.room.every((roomId) =>{
+        return this._empty_rooms.includes(roomId);
+      })) {
+        log.verbose("Timeline", "Skipping #%s because no real users are using it.", feed.hashtag);
+        return;
+      }
+    }
+
     var req = {
       q: "%23"+feed.hashtag,
       result_type: 'recent',
@@ -296,35 +347,49 @@ class Timeline {
       this._newtags.delete("#"+feed.hashtag);
     }
 
-    this.twitter.storage.get_since(feed.hashtag).then((since) => {
-      log.silly("Polling %s, since value: %s", feed.hashtag, since);
-      if (since) {
-        req.since_id = since;
-      }
-      return this.twitter.client_factory.get_client();
-    }).then((client)=>{
-      return client.getAsync('search/tweets', req);
-    }).then((results) => {
-      if (results.statuses.length === 0) {
-        return;
-      }
-      else{
-        if(results.statuses.length === HASHTAG_TWEET_FETCH_COUNT) {
-          log.info("Hashtag poll request hit count limit. Request likely incomplete.");
-        }
-      }
-      const s = results.statuses[0].id_str;
-      this.twitter.storage.set_since(feed.hashtag, s);
-      log.silly("Storing since: %s", s);
-      this.twitter.processor.process_tweets(feed.room, results.statuses, 0);
-    }).catch((error) => {
-      log.error("_process_hashtag_feed: GET /search/tweets returned: %s", error);
-    });
-
-    this._h++;
-    if(this._h >= this._hashtags.length) {
-      this._h = 0;
+    const since = yield this.twitter.storage.get_since(feed.hashtag);
+    if (since) {
+      req.since_id = since;
     }
+    let results;
+    try {
+      results = yield client.getAsync('search/tweets', req);
+    }
+    catch (error) {
+      log.error("Timeline", "_process_hashtags: GET /search/tweets returned: %s", error.code);
+      return;
+    }
+    if (results.statuses.length === 0) {
+      return;
+    }
+    else if(results.statuses.length === HASHTAG_TWEET_FETCH_COUNT) {
+      log.info("Timeline", "Poll request hit count limit. Request likely incomplete.");
+    }
+    const s = results.statuses[0].id_str;
+    this.twitter.storage.set_since(feed.hashtag, s);
+    // If req.count = 1, the resp will be the initial tweet used to get initial "since"
+    if (req.count !== 1) {
+      try {
+        yield this.twitter.processor.process_tweets(feed.room, results.statuses, 0);
+      }
+      catch(err) {
+        log.error("Timeline", "Error whilst processing hashtag feed %s: %s", feed.hashtag, err);
+      }
+    }
+  }
+
+  * _check_empty_rooms () {
+    const bot = this.twitter.bridge.getBot();
+    const memberLists = yield bot.getMemberLists();
+    const empty_room_list = [];
+    for (const room in memberLists) {
+      if (memberLists[room].realJoinedUsers.length === 0) {
+        log.silly("Timeline", "%s has no real users", room);
+        empty_room_list.push(room);
+      }
+    }
+    this._empty_rooms = empty_room_list;
+    return false;
   }
 
   _find_timeline (twitter_id) {

--- a/src/twitter/Timeline.js
+++ b/src/twitter/Timeline.js
@@ -233,10 +233,12 @@ class Timeline {
   }
 
   _remove_from_queue (isTimeline, id, room_id) {
+    // Get the index of the item and it's associated queue.
     const i = isTimeline ? this._find_timeline(id) : this._find_hashtag(id);
     const queue = isTimeline ? this._timelines : this._hashtags;
+    const removeSingle = room_id !== undefined;
     if(i !== -1) {
-      if(room_id) {
+      if(removeSingle) {
         if (queue[i].room.has(room_id)) {
           queue[i].room.delete(room_id);
         }
@@ -246,8 +248,11 @@ class Timeline {
         }
       }
       else {
+        // Remove the whole timeline.
         queue[i].room.clear();
       }
+
+      // Are any rooms being processed at this point. Remove if not.
       if(queue[i].room.size === 0) {
         queue.splice(i, 1);
       }
@@ -261,7 +266,7 @@ class Timeline {
       return true;
     }
     else {
-      log.warn("Tried to remove %s but it doesn't exist", id);
+      log.warn("Tried to remove %s but it isn't queued.", id);
       return false;
     }
   }

--- a/src/twitter/Timeline.js
+++ b/src/twitter/Timeline.js
@@ -119,7 +119,6 @@ class Timeline {
     const htag = this._find_hashtag(hashtag);
     let obj;
 
-
     if(opts === undefined) {
       opts = {};
     }
@@ -152,15 +151,11 @@ class Timeline {
    * Add a Twitters user's timeline to the timeline processor. Tweets will be
    * automatically send to the given room.
    *
-   * HTM* - Use a single account to send tweets, avoiding large numbers of join
-   * events. This is enabled automatically unless disabled via config
-   *
    * @param  {string} twitter_id The twitter ID of a timeline.
    * @param  {string} room_id The room_id to insert tweets into.
    * @param  {object} opts Options
    * @param  {boolean} opts.is_new Is the room 'new', and we shouldn't do a full poll.
    * @param  {boolean} opts.exclude_replies Should we not fetch replies.
-   * @param  {boolean} opts.high_traffic_mode Enable high traffic mode on the timeline*.
    * @return {boolean} was the hashtag added/changed
   */
   add_timeline (twitter_id, room_id, opts) {
@@ -197,7 +192,6 @@ class Timeline {
         twitter_id,
         room: new Set(),
         exclude_replies: opts.exclude_replies,
-        high_traffic_mode: opts.high_traffic_mode
       }
       if(opts.is_new) {
         this._newtags.add(twitter_id);

--- a/src/twitter/Timeline.js
+++ b/src/twitter/Timeline.js
@@ -79,7 +79,7 @@ class Timeline {
    */
   start_hashtag () {
     this._h_intervalID = setInterval(() => {
-      Promise.coroutine(this._process_hashtags.bind(this))();
+      Promise.coroutine(this._process_hashtag.bind(this))();
     }, HASHTAG_POLL_INTERVAL);
   }
 
@@ -112,7 +112,7 @@ class Timeline {
     if (!Util.isRoomId(room_id)) {
       throw Error("Not a valid room_id");
     }
-    if(!Util.isTwitterHashtag(hashtag)){
+    if(!Util.isTwitterHashtag(hashtag)) {
       throw Error("Not a valid hashtag");
     }
     const htag = this._find_hashtag(hashtag);
@@ -286,6 +286,7 @@ class Timeline {
     if (this._timelines.length === 0) {
       return;
     }
+    // Rotate to the next timeline.
     this._t++;
     if(this._t >= this._timelines.length) {
       this._t = 0;
@@ -342,7 +343,7 @@ class Timeline {
     return;
   }
 
-  * _process_hashtags () {
+  * _process_hashtag () {
     if (this._hashtags.length === 0) {
       return;
     }

--- a/src/twitter/Timeline.js
+++ b/src/twitter/Timeline.js
@@ -287,7 +287,6 @@ class Timeline {
     let max = (timeline ? (TIMELINE_POLL_INTERVAL*this._t) : (HASHTAG_POLL_INTERVAL*this._h))/60000;
     max = Math.max(max * NEW_PROFILE_THRESHOLD_MIN, 1)
     if (this.config.hashtags.single_account_fallback === true) {
-      console.log(tweets.length);
       const user_ids = new Set(tweets.map((tweet) => {tweet.id_str})).size;
       log.verbose(`is_feed_exceeding_user_limit: ${user_ids} > ${max}`);
       return user_ids > max;

--- a/src/twitter/Timeline.js
+++ b/src/twitter/Timeline.js
@@ -3,7 +3,7 @@ const Promise  = require('bluebird');
 
 const TIMELINE_POLL_INTERVAL = 3010; //Twitter allows 300 calls per 15 minute (We add 10 milliseconds for a little safety).
 const HASHTAG_POLL_INTERVAL = 2010; //Twitter allows 450 calls per 15 minute (We add 10 milliseconds for a little safety).
-const EMPTY_ROOM_INTERVAL = 5000;
+const EMPTY_ROOM_INTERVAL = 30000;
 const TIMELINE_TWEET_FETCH_COUNT = 100;
 const HASHTAG_TWEET_FETCH_COUNT = 100;
 const TWEET_REPLY_MAX_DEPTH = 0;

--- a/src/twitter/Twitter.js
+++ b/src/twitter/Twitter.js
@@ -32,7 +32,7 @@ class Twitter {
     this._config.timelines.poll_if_empty = this._config.timelines.poll_if_empty || false;
     this._config.hashtags.poll_if_empty = this._config.hashtags.poll_if_empty || false;
 
-    this._timeline = new Timeline(this, this._config.timelines, this._config.hashtags);
+    this._timeline = new Timeline(this, this._config);
 
     this._userstream = new UserStream(this);
     this._status = new Status(this);
@@ -73,7 +73,7 @@ class Twitter {
       }
 
       if (this._config.hashtags.enable || this._config.timelines.enable) {
-        this.timeline.start_empty_room_checker();
+        this.timeline.startMemberChecker();
       }
 
       this._userstream.start();
@@ -93,7 +93,7 @@ class Twitter {
   stop () {
     this.timeline.stop_timeline();
     this.timeline.stop_hashtag();
-    this.timeline.stop_empty_room_checker();
+    this.timeline.stopMemberChecker();
     this._userstream.detach_all();
     this._userstream.stop();
   }

--- a/src/twitter/Twitter.js
+++ b/src/twitter/Twitter.js
@@ -142,13 +142,13 @@ class Twitter {
 
   notify_matrix_user (user, message) {
     const roomstore = this._bridge.getRoomStore();
-    roomstore.getEntriesByRemoteId("service_"+user).then((items) => {
+    roomstore.getEntriesByRemoteId("service_" + user).then((items) => {
       log.info('Sending %s "%s"', user, message);
       if(items.length === 0) {
         log.warn("Couldn't find service room for %s, so couldn't send notice.", user);
         return;
       }
-      const latest_service = items[items.length-1].matrix.getId();
+      const latest_service = items[items.length - 1].matrix.getId();
       this._bridge.getIntent().sendMessage(latest_service, {"msgtype": "m.notice", "body": message});
     });
   }
@@ -168,7 +168,7 @@ class Twitter {
       }
       const intent = this._bridge.getIntent();
       const users = {};
-      users["@_twitter_bot:"+this._bridge.opts.domain] = 100;
+      users["@_twitter_bot:" + this._bridge.opts.domain] = 100;
       users[user] = 100;
       const powers = util.roomPowers(users);
       //Create the room
@@ -194,7 +194,7 @@ class Twitter {
       ).then(room =>{
         log.verbose("Created new user timeline room %s", room.room_id);
         const mroom = new Bridge.MatrixRoom(room.room_id);
-        const rroom = new Bridge.RemoteRoom("tl_"+user);
+        const rroom = new Bridge.RemoteRoom("tl_" + user);
         rroom.set("twitter_type", "user_timeline");
         rroom.set("twitter_bidirectional", true);
         rroom.set("twitter_owner", user);

--- a/src/twitter/Twitter.js
+++ b/src/twitter/Twitter.js
@@ -31,6 +31,9 @@ class Twitter {
     this._dm = new DirectMessage(this);
     this._config.timelines.poll_if_empty = this._config.timelines.poll_if_empty || false;
     this._config.hashtags.poll_if_empty = this._config.hashtags.poll_if_empty || false;
+    this._config.timelines.poll_if_empty = this._config.timelines.poll_if_empty || false;
+    this._config.hashtags.poll_if_empty = this._config.hashtags.poll_if_empty || false;
+
     this._timeline = new Timeline(this, this._config.timelines, this._config.hashtags);
 
     this._userstream = new UserStream(this);
@@ -71,6 +74,11 @@ class Twitter {
         this.timeline.start_hashtag();
       }
       this._userstream.start();
+
+      if (this._config.hashtags.enable && this._config.timelines.enable) {
+        this.timeline.start_empty_room_checker();
+      }
+
       this._userstream.attach_all();
 
       this._processor.start();
@@ -89,6 +97,7 @@ class Twitter {
   stop () {
     this.timeline.stop_timeline();
     this.timeline.stop_hashtag();
+    this.timeline.stop_empty_room_checker();
     this._userstream.detach_all();
     this._userstream.stop();
   }

--- a/src/twitter/Twitter.js
+++ b/src/twitter/Twitter.js
@@ -62,7 +62,7 @@ class Twitter {
         storage: this._storage,
         media: this._config.media
       });
-
+      this._processor.start();
 
       if (this._config.timelines.enable) {
         this.timeline.start_timeline();
@@ -71,19 +71,13 @@ class Twitter {
       if (this._config.hashtags.enable) {
         this.timeline.start_hashtag();
       }
+
+      if (this._config.hashtags.enable || this._config.timelines.enable) {
+        this.timeline.start_empty_room_checker();
+      }
+
       this._userstream.start();
-
-      if (this._config.hashtags.enable && this._config.timelines.enable) {
-        this.timeline.start_empty_room_checker();
-      }
-
-      if (this._config.hashtags.enable && this._config.timelines.enable) {
-        this.timeline.start_empty_room_checker();
-      }
-
       this._userstream.attach_all();
-
-      this._processor.start();
 
     }).catch((error) => {
       log.error('Error trying to retrieve bearer token:', error);

--- a/src/twitter/Twitter.js
+++ b/src/twitter/Twitter.js
@@ -155,11 +155,11 @@ class Twitter {
       if(troom != null) {
         return;
       }
-      var intent = this._bridge.getIntent();
-      var users = {};
+      const intent = this._bridge.getIntent();
+      const users = {};
       users["@_twitter_bot:"+this._bridge.opts.domain] = 100;
       users[user] = 100;
-      var powers = util.roomPowers(users);
+      const powers = util.roomPowers(users);
       //Create the room
       return intent.createRoom(
         {
@@ -182,8 +182,8 @@ class Twitter {
         }
       ).then(room =>{
         log.verbose("Created new user timeline room %s", room.room_id);
-        var mroom = new Bridge.MatrixRoom(room.room_id);
-        var rroom = new Bridge.RemoteRoom("tl_"+user);
+        const mroom = new Bridge.MatrixRoom(room.room_id);
+        const rroom = new Bridge.RemoteRoom("tl_"+user);
         rroom.set("twitter_type", "user_timeline");
         rroom.set("twitter_bidirectional", true);
         rroom.set("twitter_owner", user);

--- a/src/twitter/Twitter.js
+++ b/src/twitter/Twitter.js
@@ -31,6 +31,9 @@ class Twitter {
     this._dm = new DirectMessage(this);
     this._config.timelines.poll_if_empty = this._config.timelines.poll_if_empty || false;
     this._config.hashtags.poll_if_empty = this._config.hashtags.poll_if_empty || false;
+    this._config.timelines.poll_if_empty = this._config.timelines.poll_if_empty || false;
+    this._config.hashtags.poll_if_empty = this._config.hashtags.poll_if_empty || false;
+
     this._timeline = new Timeline(this, this._config.timelines, this._config.hashtags);
 
     this._userstream = new UserStream(this);
@@ -71,6 +74,10 @@ class Twitter {
         this.timeline.start_hashtag();
       }
 
+      if (this._config.hashtags.enable && this._config.timelines.enable) {
+        this.timeline.start_empty_room_checker();
+      }
+
       this._userstream.attach_all();
 
       this._processor.start();
@@ -89,6 +96,7 @@ class Twitter {
   stop () {
     this.timeline.stop_timeline();
     this.timeline.stop_hashtag();
+    this.timeline.stop_empty_room_checker();
     this._userstream.detach_all();
   }
 

--- a/src/twitter/Twitter.js
+++ b/src/twitter/Twitter.js
@@ -31,8 +31,6 @@ class Twitter {
     this._dm = new DirectMessage(this);
     this._config.timelines.poll_if_empty = this._config.timelines.poll_if_empty || false;
     this._config.hashtags.poll_if_empty = this._config.hashtags.poll_if_empty || false;
-    this._config.timelines.poll_if_empty = this._config.timelines.poll_if_empty || false;
-    this._config.hashtags.poll_if_empty = this._config.hashtags.poll_if_empty || false;
 
     this._timeline = new Timeline(this, this._config.timelines, this._config.hashtags);
 

--- a/src/twitter/Twitter.js
+++ b/src/twitter/Twitter.js
@@ -70,7 +70,7 @@ class Twitter {
       if (this._config.hashtags.enable) {
         this.timeline.start_hashtag();
       }
-
+      this._userstream.start();
       this._userstream.attach_all();
 
       this._processor.start();
@@ -90,6 +90,7 @@ class Twitter {
     this.timeline.stop_timeline();
     this.timeline.stop_hashtag();
     this._userstream.detach_all();
+    this._userstream.stop();
   }
 
   get dm () {

--- a/src/twitter/TwitterClientFactory.js
+++ b/src/twitter/TwitterClientFactory.js
@@ -5,7 +5,7 @@ const Buffer   = require('buffer').Buffer;
 const Twitter  = require('twitter');
 const Promise = require('bluebird');
 
-const TWITTER_CLIENT_INTERVAL_MS    = 60000*12; // Check creds every 12 hours.
+const TWITTER_CLIENT_INTERVAL_MS    = 60000 * 12; // Check creds every 12 hours.
 
 /**
   * Deals with authentication

--- a/src/twitter/TwitterClientFactory.js
+++ b/src/twitter/TwitterClientFactory.js
@@ -53,7 +53,7 @@ class TwitterClientFactory {
     }).then(token => {
       //Test the token
       return new Promise((resolve, reject) =>{
-        var auth = {
+        const auth = {
           consumer_key: this._auth_config.consumer_key,
           consumer_secret: this._auth_config.consumer_secret,
           bearer_token: token
@@ -92,9 +92,9 @@ class TwitterClientFactory {
 
   _get_bearer_http () {
     return new Promise( (resolve, reject) => {
-      var key = this._auth_config.consumer_key + ":" + this._auth_config.consumer_secret;
+      let key = this._auth_config.consumer_key + ":" + this._auth_config.consumer_secret;
       key = Buffer.from(key, 'ascii').toString('base64');
-      var options = {
+      const options = {
         url: "https://api.twitter.com/oauth2/token",
         headers: {
           'Authorization': "Basic " + key
@@ -113,10 +113,12 @@ class TwitterClientFactory {
                 response.statusCode
               );
         } else {
+          let jsonresponse;
           try {
-            var jsonresponse = JSON.parse(body);
+            jsonresponse = JSON.parse(body);
           } catch (e) {
             reject(e);
+            return;
           }
           if (jsonresponse.token_type === "bearer") {
             FS.writeFile("bearer.tok", jsonresponse.access_token, (err) => {
@@ -151,9 +153,9 @@ class TwitterClientFactory {
         throw "No twitter account linked.";
       }
 
-      var ts = new Date().getTime();
-      var id = creds.user_id;
-      var client = this._tclients.has(id) ? this._tclients.get(id) : this._create_twitter_client(creds);
+      const ts = new Date().getTime();
+      const id = creds.user_id;
+      const client = this._tclients.has(id) ? this._tclients.get(id) : this._create_twitter_client(creds);
       if(ts - client.last_auth < TWITTER_CLIENT_INTERVAL_MS) {
         return client;
       }
@@ -189,7 +191,7 @@ class TwitterClientFactory {
   }
 
   _create_twitter_client (creds) {
-    var client = new Twitter({
+    const client = new Twitter({
       consumer_key: this._auth_config.consumer_key,
       consumer_secret: this._auth_config.consumer_secret,
       access_token_key: creds.access_token,

--- a/src/twitter/TwitterProfile.js
+++ b/src/twitter/TwitterProfile.js
@@ -16,7 +16,7 @@ class TwitterProfile {
   }
 
   * _update_profile (new_profile) {
-    var ts = new Date().getTime();
+    const ts = new Date().getTime();
     if(new_profile == null) {
       throw Error("Tried to preform a profile update with a null profile.");
     }
@@ -83,7 +83,7 @@ class TwitterProfile {
       });
     }
 
-    var url = null;
+    let url = null;
     if(update_avatar) {
       log.verbose(`Updating avatar for @${new_profile.screen_name}`);
       //We have to replace _normal because it gives us a bad quality image

--- a/src/twitter/UserStream.js
+++ b/src/twitter/UserStream.js
@@ -124,6 +124,7 @@ class UserStream {
 
   detach (user_id) {
     if(this._user_streams.has(user_id)) {
+      this._user_keepalive.delete(user_id);
       this._user_streams.get(user_id).destroy();
       this._user_streams.delete(user_id);
       log.info("UserStream", "Detached stream for ", user_id);

--- a/src/twitter/UserStream.js
+++ b/src/twitter/UserStream.js
@@ -91,7 +91,7 @@ class UserStream {
         log.info(
           "UserStream",
           "Got 'end'. %s",
-          response
+          JSON.stringify(response)
         );
       });
       stream.on('error', (error) => {this._on_error(error, user_id)});

--- a/src/twitter/UserStream.js
+++ b/src/twitter/UserStream.js
@@ -56,7 +56,7 @@ class UserStream {
     }
 
     this._user_streams.set(user_id, "pending");//Block race attempts;
-    var client;
+    let client;
     return this.twitter.client_factory.get_client(user_id).then((c) => {
       if(!c) {
         this._user_streams.delete(user_id);

--- a/src/twitter/UserStream.js
+++ b/src/twitter/UserStream.js
@@ -1,9 +1,9 @@
 const log  = require('../logging.js');
 
 const STREAM_RETRY_INTERVAL = 5000;
-const BACKOFF_NOTIFY_USER_AT = (1000*60*2);
-const STREAM_LOCKOUT_RETRY_INTERVAL = 60*60*1000;
-const STREAM_CONCERN_TIMER = 40*60*1000; // Twitter should send something every 30s.
+const BACKOFF_NOTIFY_USER_AT = (1000 * 60 * 2);
+const STREAM_LOCKOUT_RETRY_INTERVAL = 60 * 60 * 1000;
+const STREAM_CONCERN_TIMER = 40 * 60 * 1000; // Twitter should send something every 30s.
 const TWEET_REPLY_MAX_DEPTH = 0;
 
 class UserStream {
@@ -107,18 +107,18 @@ class UserStream {
   }
 
   _on_error (error, user_id) {
-    const backoff =  2 * (this._backoff.has(user_id) ? this._backoff.get(user_id) : STREAM_RETRY_INTERVAL/2);
+    const backoff =  2 * (this._backoff.has(user_id) ? this._backoff.get(user_id) : STREAM_RETRY_INTERVAL / 2);
     this._backoff.set(user_id, backoff);
     if (backoff >= BACKOFF_NOTIFY_USER_AT) {
       this.twitter.notify_matrix_user(user_id,
-        `Currently experiencing connection issues with Twitter. Will retry to connect in ${backoff/1000} seconds.
+        `Currently experiencing connection issues with Twitter. Will retry to connect in ${backoff / 1000} seconds.
         If this continues, notify the bridge maintainer.`);
     }
     this.detach(user_id);
     setTimeout(() => {this.attach(user_id); }, backoff);
     log.error(
       "UserStream",
-      "Stream gave an error %s. Detaching for %s seconds for %s.", error, backoff/1000, user_id
+      "Stream gave an error %s. Detaching for %s seconds for %s.", error, backoff / 1000, user_id
     );
   }
 

--- a/src/twitter/UserStream.js
+++ b/src/twitter/UserStream.js
@@ -158,7 +158,7 @@ class UserStream {
         return this.twitter.storage.get_timeline_room(user_id);
       }).then((room) =>{
         if(room !== null) {
-          this.twitter.processor.process_tweet(room.room_id, data, TWEET_REPLY_MAX_DEPTH, client);
+          this.twitter.processor.process_tweet(room.room_id, data, {depth: TWEET_REPLY_MAX_DEPTH, client});
         }
         else{
           log.verbose("UserStream", `${user_id} does not have a registered timeline view for their stream.`);

--- a/src/util.js
+++ b/src/util.js
@@ -22,7 +22,7 @@ function downloadFile (url) {
 
     const ht = url.startsWith("https") ? https : http;
     const req = ht.get((url), (res) => {
-      var buffer = Buffer.alloc(0);
+      let buffer = Buffer.alloc(0);
       if(res.statusCode !== 200) {
         reject(`Non 200 status code (${res.statusCode}) `)
       }
@@ -61,7 +61,7 @@ function formatStringFromObject (fmtstring, obj) {
  * @return {Promise<string>}  Promise resolving with a MXC URL.
  */
 function uploadContentFromUrl (bridge, url, id, name) {
-  var contenttype;
+  let contenttype;
   let size;
   id = id || null;
   name = name || null;

--- a/test/db/test_dm.js
+++ b/test/db/test_dm.js
@@ -4,7 +4,7 @@ const assert = chai.assert;
 const TwitterDB = require('../../src/TwitterDB.js');
 
 describe('TwitterDB.dm', function () {
-  var db;
+  let db;
   beforeEach(() => {
     db = new TwitterDB(":memory:");
     return db.init();
@@ -26,7 +26,7 @@ describe('TwitterDB.dm', function () {
   describe('get_dm_room()', () => {
 
     it("should return null if no entry exists", () => {
-      var promise = db.get_dm_room("potato");
+      const promise = db.get_dm_room("potato");
       return assert.isFulfilled(promise) && assert.becomes(promise, null);
     });
 
@@ -42,7 +42,7 @@ describe('TwitterDB.dm', function () {
   describe('get_users_from_dm_room()', () => {
 
     it("should return null if no entry exists", () => {
-      var promise = db.get_users_from_dm_room("potato");
+      const promise = db.get_users_from_dm_room("potato");
       return assert.isFulfilled(promise) && assert.becomes(promise, null);
     });
 

--- a/test/db/test_event.js
+++ b/test/db/test_event.js
@@ -8,7 +8,7 @@ global.Promise = require('bluebird');
 require('../../src/logging.js').init({level: 'silent'});
 
 describe('TwitterDB.dm', function () {
-  var db;
+  let db;
   beforeEach(() => {
     db = new TwitterDB(":memory:");
     return db.init();

--- a/test/handlers/test_Timeline.js
+++ b/test/handlers/test_Timeline.js
@@ -10,8 +10,6 @@ const Timeout = setTimeout(function () { }, 0).constructor; // Only way to acces
 require('../../src/logging.js').init({level: 'silent'});
 describe('Timeline', function () {
   let timeline;
-  let _process_timeline; //For coroutine.
-  let _process_hashtag; //For coroutine.
   let _check_empty_rooms; //For coroutine.
   let _since = null;
   let _tweets_fetched;
@@ -73,8 +71,6 @@ describe('Timeline', function () {
     }, {
       enable: true,
     });
-    _process_timeline = Promise.coroutine(timeline._process_timeline.bind(timeline));
-    _process_hashtag = Promise.coroutine(timeline._process_hashtag.bind(timeline));
     _check_empty_rooms = Promise.coroutine(timeline._check_empty_rooms.bind(timeline));
   });
 
@@ -229,9 +225,9 @@ describe('Timeline', function () {
     });
   });
 
-  describe('_process_timeline', function () {
+  describe('timeline._process_timeline', function () {
     it('should not process if the timeline list is empty.', function () {
-      return _process_timeline().then(() => {
+      return timeline._process_timeline().then(() => {
         assert.equal(timeline._t, -1);
       });
     });
@@ -241,7 +237,7 @@ describe('Timeline', function () {
         room: new Set(["bacon"])
       });
       timeline._empty_rooms.add("bacon");
-      return _process_timeline().then(() => {
+      return timeline._process_timeline().then(() => {
         assert.isFalse(_tweets_fetched);
       });
     });
@@ -250,7 +246,7 @@ describe('Timeline', function () {
         twitter_id: "test",
         room: new Set(["bacon"])
       });
-      return _process_timeline().then(() => {
+      return timeline._process_timeline().then(() => {
         assert.equal(timeline._t, 0, "Queue is incremented.");
         assert.equal(_since, "0");
       });
@@ -268,15 +264,15 @@ describe('Timeline', function () {
         twitter_id: "test2",
         room: new Set(["bacon"])
       });
-      return _process_timeline().then(() => {
+      return timeline._process_timeline().then(() => {
         assert.equal(timeline._t, 0, "Queue is incremented.");
-        return _process_timeline();
+        return timeline._process_timeline();
       }).then(() => {
         assert.equal(timeline._t, 1, "Queue is incremented.");
-        return _process_timeline();
+        return timeline._process_timeline();
       }).then(() => {
         assert.equal(timeline._t, 2, "Queue is incremented.");
-        return _process_timeline();
+        return timeline._process_timeline();
       }).then(() => {
         assert.equal(timeline._t, 0, "Queue is incremented.");
       });
@@ -287,16 +283,16 @@ describe('Timeline', function () {
         room: new Set(["bacon"])
       });
       timeline._newtags.add("test");
-      return _process_timeline().then(() => {
+      return timeline._process_timeline().then(() => {
         assert.equal(timeline._t, 0, "Queue is incremented.");
         assert.equal(_since, "0");
         assert.isFalse(timeline._newtags.has("test"));
       });
     });
   });
-  describe('_process_hashtags', function () {
+  describe('timeline._process_hashtags', function () {
     it('should not process if the hashtag list is empty.', function () {
-      return _process_hashtag().then(() => {
+      timeline._process_hashtag().then(() => {
         assert.equal(timeline._h, -1);
       });
     });
@@ -306,7 +302,7 @@ describe('Timeline', function () {
         room: new Set(["bacon"])
       });
       timeline._empty_rooms.add("bacon");
-      return _process_hashtag().then(() => {
+      return timeline._process_hashtag().then(() => {
         assert.isFalse(_tweets_fetched);
       });
     });
@@ -315,7 +311,7 @@ describe('Timeline', function () {
         hashtag: "test",
         room: new Set(["bacon"])
       });
-      return _process_hashtag().then(() => {
+      return timeline._process_hashtag().then(() => {
         assert.equal(timeline._h, 0, "Queue is incremented.");
         assert.equal(_since, "0");
       });
@@ -333,15 +329,15 @@ describe('Timeline', function () {
         hashtag: "test2",
         room: new Set(["bacon"])
       });
-      return _process_hashtag().then(() => {
+      return timeline._process_hashtag().then(() => {
         assert.equal(timeline._h, 0, "Queue is incremented.");
-        return _process_hashtag();
+        return timeline._process_hashtag();
       }).then(() => {
         assert.equal(timeline._h, 1, "Queue is incremented.");
-        return _process_hashtag();
+        return timeline._process_hashtag();
       }).then(() => {
         assert.equal(timeline._h, 2, "Queue is incremented.");
-        return _process_hashtag();
+        return timeline._process_hashtag();
       }).then(() => {
         assert.equal(timeline._h, 0, "Queue is incremented.");
       });
@@ -352,7 +348,7 @@ describe('Timeline', function () {
         room: new Set(["bacon"])
       });
       timeline._newtags.add("#test");
-      return _process_hashtag().then(() => {
+      return timeline._process_hashtag().then(() => {
         assert.equal(timeline._h, 0, "Queue is incremented.");
         assert.equal(_since, "0");
         assert.isFalse(timeline._newtags.has("#test"));

--- a/test/handlers/test_Timeline.js
+++ b/test/handlers/test_Timeline.js
@@ -1,0 +1,374 @@
+const chai = require('chai');
+chai.use(require("chai-as-promised"));
+const assert = chai.assert;
+const Timeline = require('../../src/twitter/Timeline.js');
+const Promise  = require('bluebird');
+
+const Timeout = setTimeout(function () { }, 0).constructor; // Only way to access Timeout
+
+// Initialise logging
+require('../../src/logging.js').init({level: 'silent'});
+describe('Timeline', function () {
+  let timeline;
+  let _process_timeline; //For coroutine.
+  let _process_hashtags; //For coroutine.
+  let _check_empty_rooms; //For coroutine.
+  let _since = null;
+  let _tweets_fetched;
+  const twitter = {
+    bridge: {
+      getBot: () => {
+        return {
+          getMemberLists: () => {
+            return Promise.resolve({
+              foobar: {
+                realJoinedUsers: []
+              },
+              bazbar: {
+                realJoinedUsers: ["a", "b", "c", "d", "e"]
+              }
+            });
+          }
+        }
+      }
+    },
+    storage: {
+      get_since: () => {
+        return Promise.resolve(_since);
+      },
+      set_since: (account, since) => {
+        _since = since;
+      }
+    },
+    processor: {
+      process_tweets: () => {
+        return Promise.resolve();
+      }
+    },
+    client_factory: {
+      get_client: () => {
+        return Promise.resolve({
+          get: (path, req) => {
+            _tweets_fetched = true;
+            const feed = [];
+            for(let i = 0;i<req.count; i++) {
+              feed.push({
+                id_str: String(i)
+              });
+            }
+            if(path === "search/tweets") {
+              return Promise.resolve({statuses: feed});
+            }
+            return Promise.resolve(feed);
+          }
+        });
+      }
+    }
+  }
+  beforeEach( function () {
+    _tweets_fetched = false;
+    timeline = new Timeline(twitter, {
+      enable: true,
+      poll_if_empty: false,
+    }, {
+      enable: true,
+    });
+    _process_timeline = Promise.coroutine(timeline._process_timeline.bind(timeline));
+    _process_hashtags = Promise.coroutine(timeline._process_hashtags.bind(timeline));
+    _check_empty_rooms = Promise.coroutine(timeline._check_empty_rooms.bind(timeline));
+  });
+
+  describe('empty room timers', function () {
+    it('start_empty_room_checker/stop_empty_room_checker should control the timer', function () {
+      timeline.start_empty_room_checker();
+      assert.instanceOf(timeline._empty_intervalID, Timeout);
+      timeline.stop_empty_room_checker();
+      assert.isNull(timeline._empty_intervalID);
+    });
+    it('should fail if not started', function () {
+      assert.throws(timeline.stop_empty_room_checker.bind(timeline));
+    });
+  });
+
+  describe('timeline timers', function () {
+    it('start_timeline/stop_timeline should control the timer', function () {
+      timeline.start_timeline();
+      assert.instanceOf(timeline._t_intervalID, Timeout);
+      timeline.stop_timeline();
+      assert.isNull(timeline._t_intervalID);
+    });
+    it('should fail if not started', function () {
+      assert.throws(timeline.stop_timeline.bind(timeline));
+    });
+  });
+
+  describe('hashtag timers', function () {
+    it('start_hashtag/stop_hashtag should control the timer', function () {
+      timeline.start_hashtag();
+      assert.instanceOf(timeline._h_intervalID, Timeout);
+      timeline.stop_hashtag();
+      assert.isNull(timeline._h_intervalID);
+    });
+    it('should fail if not started', function () {
+      assert.throws(timeline.stop_hashtag.bind(timeline));
+    });
+  });
+
+  describe('add_hashtag', function () {
+    it('must not add a timeline if the config denys it', function () {
+      timeline = new Timeline(null, {}, {
+        enable: false,
+      });
+      assert.isFalse(timeline.add_hashtag("string", "!room:someplace"));
+    });
+    it('should add a new hashtag with no opts and invalid room', function () {
+      assert.throws(() => {
+        timeline.add_hashtag("test");
+      }, "Not a valid room_id");
+      assert.throws(() => {
+        timeline.add_hashtag("test", "somewords");
+      }, "Not a valid room_id");
+    });
+    it('should add a new invalid hashtag', function () {
+      assert.throws(() => {
+        timeline.add_hashtag("£$^£$£$", "!room:someplace");
+      }, "Not a valid hashtag");
+    });
+    it('should add a new hashtag without is_new', function () {
+      assert.isTrue(timeline.add_hashtag("test", "!room:someplace"));
+      assert.equal(timeline._hashtags[0].hashtag, "test");
+      assert.isTrue(timeline._hashtags[0].room.has("!room:someplace"));
+    });
+    it('should add a new hashtag with is_new', function () {
+      assert.isTrue(timeline.add_hashtag("test", "!room:someplace", {is_new: true}));
+      assert.isTrue(timeline._newtags.has("#test"));
+    });
+    it('should update an existing hashtag with a new room', function () {
+      assert.isTrue(timeline.add_hashtag("test", "!room:someplace"));
+      assert.isTrue(timeline._hashtags[0].room.has("!room:someplace"));
+      assert.isTrue(timeline.add_hashtag("test", "!room2:someplace"));
+      assert.sameMembers([...timeline._hashtags[0].room], ["!room:someplace", "!room2:someplace"]);
+    });
+  });
+
+  describe('add_timeline', function () {
+    it('must not add a timeline if the config denys it', function () {
+      timeline = new Timeline(null, {
+        enable: false,
+      }, {});
+      assert.isFalse(timeline.add_timeline("string", "!room:someplace"));
+    });
+    it('should add a new timeline with no opts and invalid room', function () {
+      assert.throws(() => {
+        timeline.add_timeline("test");
+      }, "Not a valid room_id");
+      assert.throws(() => {
+        timeline.add_timeline("test", "somewords");
+      }, "Not a valid room_id");
+    });
+    it('should add a new timeline without is_new', function () {
+      assert.isTrue(timeline.add_timeline("test", "!room:someplace"));
+      assert.equal(timeline._timelines[0].twitter_id, "test");
+      assert.isTrue(timeline._timelines[0].room.has("!room:someplace"));
+    });
+    it('should add a new timeline with is_new', function () {
+      assert.isTrue(timeline.add_timeline("test", "!room:someplace", {is_new: true}));
+      assert.isTrue(timeline._newtags.has("test"));
+    });
+    it('should update an existing timeline with a new room', function () {
+      assert.isTrue(timeline.add_timeline("test", "!room:someplace"));
+      assert.isTrue(timeline._timelines[0].room.has("!room:someplace"));
+      assert.isTrue(timeline.add_timeline("test", "!room2:someplace"));
+      assert.sameMembers([...timeline._timelines[0].room], ["!room:someplace", "!room2:someplace"]);
+    });
+  });
+
+  describe('remove_timeline', function () {
+    it('should return false if the timeline does not exist', function () {
+      assert.isFalse(timeline.remove_timeline("test", "!room:someplace"));
+    });
+    it('should remove a timeline.', function () {
+      timeline._timelines.push({
+        twitter_id: "test",
+        room: new Set()
+      });
+      timeline._timelines.push({
+        twitter_id: "test2",
+        room: new Set()
+      });
+      timeline._timelines.push({
+        twitter_id: "test3",
+        room: new Set()
+      });
+      assert.isTrue(timeline.remove_timeline("test"));
+      assert.equal(timeline._timelines[0].twitter_id, "test2");
+      assert.equal(timeline._timelines[1].twitter_id, "test3");
+      assert.isTrue(timeline.remove_timeline("test2"));
+      assert.equal(timeline._timelines[0].twitter_id, "test3");
+    });
+    it('should remove a timeline with a single room.', function () {
+      timeline._timelines.push({
+        twitter_id: "test",
+        room: new Set(["bacon"])
+      })
+      assert.isTrue(timeline.remove_timeline("test", "bacon"));
+      assert.equal(timeline._timelines.length, 0);
+    });
+    it('should return true if the room does not exist', function () {
+      timeline._timelines.push({
+        twitter_id: "test",
+        room: new Set(["bacon"])
+      })
+      assert.isTrue(timeline.remove_timeline("test", "!room:someplace"));
+      assert.deepEqual(timeline._timelines, [
+        {
+          twitter_id: "test",
+          room: new Set(["bacon"])
+        }
+      ]);
+    });
+  });
+
+  describe('_process_timeline', function () {
+    it('should not process if the timeline list is empty.', function () {
+      return _process_timeline().then(() => {
+        assert.equal(timeline._t, -1);
+      });
+    });
+    it('should skip empty rooms.', function () {
+      timeline._timelines.push({
+        twitter_id: "test",
+        room: new Set(["bacon"])
+      });
+      timeline._empty_rooms.add("bacon");
+      return _process_timeline().then(() => {
+        assert.isFalse(_tweets_fetched);
+      });
+    });
+    it('should fetch some tweets.', function () {
+      timeline._timelines.push({
+        twitter_id: "test",
+        room: new Set(["bacon"])
+      });
+      return _process_timeline().then(() => {
+        assert.equal(timeline._t, 0, "Queue is incremented.");
+        assert.equal(_since, "0");
+      });
+    });
+    it('should wrap around queue.', function () {
+      timeline._timelines.push({
+        twitter_id: "test",
+        room: new Set(["bacon"])
+      });
+      timeline._timelines.push({
+        twitter_id: "test1",
+        room: new Set(["bacon"])
+      });
+      timeline._timelines.push({
+        twitter_id: "test2",
+        room: new Set(["bacon"])
+      });
+      return _process_timeline().then(() => {
+        assert.equal(timeline._t, 0, "Queue is incremented.");
+        return _process_timeline();
+      }).then(() => {
+        assert.equal(timeline._t, 1, "Queue is incremented.");
+        return _process_timeline();
+      }).then(() => {
+        assert.equal(timeline._t, 2, "Queue is incremented.");
+        return _process_timeline();
+      }).then(() => {
+        assert.equal(timeline._t, 0, "Queue is incremented.");
+      });
+    });
+    it('should fetch a tweet for _newtags mode.', function () {
+      timeline._timelines.push({
+        twitter_id: "test",
+        room: new Set(["bacon"])
+      });
+      timeline._newtags.add("test");
+      return _process_timeline().then(() => {
+        assert.equal(timeline._t, 0, "Queue is incremented.");
+        assert.equal(_since, "0");
+        assert.isFalse(timeline._newtags.has("test"));
+      });
+    });
+  });
+  describe('_process_hashtags', function () {
+    it('should not process if the hashtag list is empty.', function () {
+      return _process_hashtags().then(() => {
+        assert.equal(timeline._h, -1);
+      });
+    });
+    it('should skip empty rooms.', function () {
+      timeline._hashtags.push({
+        hashtag: "test",
+        room: new Set(["bacon"])
+      });
+      timeline._empty_rooms.add("bacon");
+      return _process_hashtags().then(() => {
+        assert.isFalse(_tweets_fetched);
+      });
+    });
+    it('should fetch some tweets.', function () {
+      timeline._hashtags.push({
+        hashtag: "test",
+        room: new Set(["bacon"])
+      });
+      return _process_hashtags().then(() => {
+        assert.equal(timeline._h, 0, "Queue is incremented.");
+        assert.equal(_since, "0");
+      });
+    });
+    it('should wrap around queue.', function () {
+      timeline._hashtags.push({
+        hashtag: "test",
+        room: new Set(["bacon"])
+      });
+      timeline._hashtags.push({
+        hashtag: "test1",
+        room: new Set(["bacon"])
+      });
+      timeline._hashtags.push({
+        hashtag: "test2",
+        room: new Set(["bacon"])
+      });
+      return _process_hashtags().then(() => {
+        assert.equal(timeline._h, 0, "Queue is incremented.");
+        return _process_hashtags();
+      }).then(() => {
+        assert.equal(timeline._h, 1, "Queue is incremented.");
+        return _process_hashtags();
+      }).then(() => {
+        assert.equal(timeline._h, 2, "Queue is incremented.");
+        return _process_hashtags();
+      }).then(() => {
+        assert.equal(timeline._h, 0, "Queue is incremented.");
+      });
+    });
+    it('should fetch a tweet for _newtags mode.', function () {
+      timeline._hashtags.push({
+        hashtag: "test",
+        room: new Set(["bacon"])
+      });
+      timeline._newtags.add("#test");
+      return _process_hashtags().then(() => {
+        assert.equal(timeline._h, 0, "Queue is incremented.");
+        assert.equal(_since, "0");
+        assert.isFalse(timeline._newtags.has("#test"));
+      });
+    });
+  });
+  describe('_check_empty_rooms', function () {
+    it('should add a empty room to the set.', function () {
+      _check_empty_rooms().then(()=> {
+        assert.isTrue(timeline._empty_rooms.has("foobar"));
+      })
+    });
+    it('should not add an active room to the set.', function () {
+      _check_empty_rooms().then(()=> {
+        assert.isFalse(timeline._empty_rooms.has("bazbar"));
+      })
+    });
+  });
+});

--- a/test/handlers/test_Timeline.js
+++ b/test/handlers/test_Timeline.js
@@ -11,7 +11,7 @@ require('../../src/logging.js').init({level: 'silent'});
 describe('Timeline', function () {
   let timeline;
   let _process_timeline; //For coroutine.
-  let _process_hashtags; //For coroutine.
+  let _process_hashtag; //For coroutine.
   let _check_empty_rooms; //For coroutine.
   let _since = null;
   let _tweets_fetched;
@@ -74,7 +74,7 @@ describe('Timeline', function () {
       enable: true,
     });
     _process_timeline = Promise.coroutine(timeline._process_timeline.bind(timeline));
-    _process_hashtags = Promise.coroutine(timeline._process_hashtags.bind(timeline));
+    _process_hashtag = Promise.coroutine(timeline._process_hashtag.bind(timeline));
     _check_empty_rooms = Promise.coroutine(timeline._check_empty_rooms.bind(timeline));
   });
 
@@ -296,7 +296,7 @@ describe('Timeline', function () {
   });
   describe('_process_hashtags', function () {
     it('should not process if the hashtag list is empty.', function () {
-      return _process_hashtags().then(() => {
+      return _process_hashtag().then(() => {
         assert.equal(timeline._h, -1);
       });
     });
@@ -306,7 +306,7 @@ describe('Timeline', function () {
         room: new Set(["bacon"])
       });
       timeline._empty_rooms.add("bacon");
-      return _process_hashtags().then(() => {
+      return _process_hashtag().then(() => {
         assert.isFalse(_tweets_fetched);
       });
     });
@@ -315,7 +315,7 @@ describe('Timeline', function () {
         hashtag: "test",
         room: new Set(["bacon"])
       });
-      return _process_hashtags().then(() => {
+      return _process_hashtag().then(() => {
         assert.equal(timeline._h, 0, "Queue is incremented.");
         assert.equal(_since, "0");
       });
@@ -333,15 +333,15 @@ describe('Timeline', function () {
         hashtag: "test2",
         room: new Set(["bacon"])
       });
-      return _process_hashtags().then(() => {
+      return _process_hashtag().then(() => {
         assert.equal(timeline._h, 0, "Queue is incremented.");
-        return _process_hashtags();
+        return _process_hashtag();
       }).then(() => {
         assert.equal(timeline._h, 1, "Queue is incremented.");
-        return _process_hashtags();
+        return _process_hashtag();
       }).then(() => {
         assert.equal(timeline._h, 2, "Queue is incremented.");
-        return _process_hashtags();
+        return _process_hashtag();
       }).then(() => {
         assert.equal(timeline._h, 0, "Queue is incremented.");
       });
@@ -352,7 +352,7 @@ describe('Timeline', function () {
         room: new Set(["bacon"])
       });
       timeline._newtags.add("#test");
-      return _process_hashtags().then(() => {
+      return _process_hashtag().then(() => {
         assert.equal(timeline._h, 0, "Queue is incremented.");
         assert.equal(_since, "0");
         assert.isFalse(timeline._newtags.has("#test"));

--- a/test/handlers/test_Timeline.js
+++ b/test/handlers/test_Timeline.js
@@ -133,7 +133,7 @@ describe('Timeline', function () {
     it('should add a new hashtag without is_new', function () {
       assert.isTrue(timeline.add_hashtag("test", "!room:someplace"));
       assert.equal(timeline._hashtags[0].hashtag, "test");
-      assert.isTrue(timeline._hashtags[0].room.has("!room:someplace"));
+      assert.isTrue(timeline._hashtags[0].rooms.has("!room:someplace"));
     });
     it('should add a new hashtag with is_new', function () {
       assert.isTrue(timeline.add_hashtag("test", "!room:someplace", {is_new: true}));
@@ -141,9 +141,9 @@ describe('Timeline', function () {
     });
     it('should update an existing hashtag with a new room', function () {
       assert.isTrue(timeline.add_hashtag("test", "!room:someplace"));
-      assert.isTrue(timeline._hashtags[0].room.has("!room:someplace"));
+      assert.isTrue(timeline._hashtags[0].rooms.has("!room:someplace"));
       assert.isTrue(timeline.add_hashtag("test", "!room2:someplace"));
-      assert.sameMembers([...timeline._hashtags[0].room], ["!room:someplace", "!room2:someplace"]);
+      assert.sameMembers([...timeline._hashtags[0].rooms], ["!room:someplace", "!room2:someplace"]);
     });
   });
 
@@ -157,7 +157,7 @@ describe('Timeline', function () {
     it('should add a new timeline without is_new', function () {
       assert.isTrue(timeline.add_timeline("test", "!room:someplace"));
       assert.equal(timeline._timelines[0].twitter_id, "test");
-      assert.isTrue(timeline._timelines[0].room.has("!room:someplace"));
+      assert.isTrue(timeline._timelines[0].rooms.has("!room:someplace"));
     });
     it('should add a new timeline with is_new', function () {
       assert.isTrue(timeline.add_timeline("test", "!room:someplace", {is_new: true}));
@@ -165,9 +165,9 @@ describe('Timeline', function () {
     });
     it('should update an existing timeline with a new room', function () {
       assert.isTrue(timeline.add_timeline("test", "!room:someplace"));
-      assert.isTrue(timeline._timelines[0].room.has("!room:someplace"));
+      assert.isTrue(timeline._timelines[0].rooms.has("!room:someplace"));
       assert.isTrue(timeline.add_timeline("test", "!room2:someplace"));
-      assert.sameMembers([...timeline._timelines[0].room], ["!room:someplace", "!room2:someplace"]);
+      assert.sameMembers([...timeline._timelines[0].rooms], ["!room:someplace", "!room2:someplace"]);
     });
   });
 
@@ -178,15 +178,15 @@ describe('Timeline', function () {
     it('should remove a timeline.', function () {
       timeline._timelines.push({
         twitter_id: "test",
-        room: new Set()
+        rooms: new Set()
       });
       timeline._timelines.push({
         twitter_id: "test2",
-        room: new Set()
+        rooms: new Set()
       });
       timeline._timelines.push({
         twitter_id: "test3",
-        room: new Set()
+        rooms: new Set()
       });
       assert.isTrue(timeline.remove_timeline("test"));
       assert.equal(timeline._timelines[0].twitter_id, "test2");
@@ -197,7 +197,7 @@ describe('Timeline', function () {
     it('should remove a timeline with a single room.', function () {
       timeline._timelines.push({
         twitter_id: "test",
-        room: new Set(["bacon"])
+        rooms: new Set(["bacon"])
       })
       assert.isTrue(timeline.remove_timeline("test", "bacon"));
       assert.equal(timeline._timelines.length, 0);
@@ -205,13 +205,13 @@ describe('Timeline', function () {
     it('should return true if the room does not exist', function () {
       timeline._timelines.push({
         twitter_id: "test",
-        room: new Set(["bacon"])
+        rooms: new Set(["bacon"])
       })
       assert.isTrue(timeline.remove_timeline("test", "!room:someplace"));
       assert.deepEqual(timeline._timelines, [
         {
           twitter_id: "test",
-          room: new Set(["bacon"])
+          rooms: new Set(["bacon"])
         }
       ]);
     });
@@ -226,7 +226,7 @@ describe('Timeline', function () {
     it('should skip empty rooms.', function () {
       timeline._timelines.push({
         twitter_id: "test",
-        room: new Set(["bacon"])
+        rooms: new Set(["bacon"])
       });
       timeline._empty_rooms.add("bacon");
       return processTimeline().then(() => {
@@ -236,7 +236,7 @@ describe('Timeline', function () {
     it('should fetch some tweets.', function () {
       timeline._timelines.push({
         twitter_id: "test",
-        room: new Set(["bacon"])
+        rooms: new Set(["bacon"])
       });
       return processTimeline().then(() => {
         assert.equal(timeline._timelineIndex, 0, "Queue is incremented.");
@@ -246,15 +246,15 @@ describe('Timeline', function () {
     it('should wrap around queue.', function () {
       timeline._timelines.push({
         twitter_id: "test",
-        room: new Set(["bacon"])
+        rooms: new Set(["bacon"])
       });
       timeline._timelines.push({
         twitter_id: "test1",
-        room: new Set(["bacon"])
+        rooms: new Set(["bacon"])
       });
       timeline._timelines.push({
         twitter_id: "test2",
-        room: new Set(["bacon"])
+        rooms: new Set(["bacon"])
       });
       return processTimeline().then(() => {
         assert.equal(timeline._timelineIndex, 0, "Queue is incremented.");
@@ -272,7 +272,7 @@ describe('Timeline', function () {
     it('should fetch a tweet for _newtags mode.', function () {
       timeline._timelines.push({
         twitter_id: "test",
-        room: new Set(["bacon"])
+        rooms: new Set(["bacon"])
       });
       timeline._newtags.add("test");
       return processTimeline().then(() => {
@@ -291,7 +291,7 @@ describe('Timeline', function () {
     it('should skip empty rooms.', function () {
       timeline._hashtags.push({
         hashtag: "test",
-        room: new Set(["bacon"])
+        rooms: new Set(["bacon"])
       });
       timeline._empty_rooms.add("bacon");
       return processHashtag().then(() => {
@@ -301,7 +301,7 @@ describe('Timeline', function () {
     it('should fetch some tweets.', function () {
       timeline._hashtags.push({
         hashtag: "test",
-        room: new Set(["bacon"])
+        rooms: new Set(["bacon"])
       });
       return processHashtag().then(() => {
         assert.equal(timeline._hashtagIndex, 0, "Queue is incremented.");
@@ -311,15 +311,15 @@ describe('Timeline', function () {
     it('should wrap around queue.', function () {
       timeline._hashtags.push({
         hashtag: "test",
-        room: new Set(["bacon"])
+        rooms: new Set(["bacon"])
       });
       timeline._hashtags.push({
         hashtag: "test1",
-        room: new Set(["bacon"])
+        rooms: new Set(["bacon"])
       });
       timeline._hashtags.push({
         hashtag: "test2",
-        room: new Set(["bacon"])
+        rooms: new Set(["bacon"])
       });
       return processHashtag().then(() => {
         assert.equal(timeline._hashtagIndex, 0, "Queue is incremented.");
@@ -337,7 +337,7 @@ describe('Timeline', function () {
     it('should fetch a tweet for _newtags mode.', function () {
       timeline._hashtags.push({
         hashtag: "test",
-        room: new Set(["bacon"])
+        rooms: new Set(["bacon"])
       });
       timeline._newtags.add("#test");
       return processHashtag().then(() => {

--- a/test/test_TweetProcessor.js
+++ b/test/test_TweetProcessor.js
@@ -20,7 +20,7 @@ const intent = {
 }
 
 const bridge = {
-  getIntent: function () {
+  getIntentFromLocalpart: function () {
     return intent;
   }
 }

--- a/twitter-as.js
+++ b/twitter-as.js
@@ -11,11 +11,11 @@ const TwitterDB = require("./src/TwitterDB.js");
 const util = require('./src/util.js');
 const Provisioner = require("./src/Provisioner.js");
 
-var twitter;
-var bridge;
-var provisioner;
+let twitter;
+let bridge;
+let provisioner;
 
-var cli = new AppService.Cli({
+const cli = new AppService.Cli({
   registrationPath: "twitter-registration.yaml",
   bridgeConfig: {
     affectsRegistration: true,
@@ -40,15 +40,13 @@ var cli = new AppService.Cli({
     }
 
     //Read registration file
-    var regObj = yaml.safeLoad(fs.readFileSync("twitter-registration.yaml", 'utf8'));
+    let regObj = yaml.safeLoad(fs.readFileSync("twitter-registration.yaml", 'utf8'));
     regObj = AppService.AppServiceRegistration.fromObject(regObj);
     if (regObj === null) {
       throw new Error("Failed to parse registration file");
     }
 
-    var room_handler;
-
-    var clientFactory = new AppService.ClientFactory({
+    const clientFactory = new AppService.ClientFactory({
       url: config.bridge.homeserverUrl,
       token: regObj.as_token,
       appServiceUserId: "@" + regObj.sender_localpart + ":" + config.bridge.domain
@@ -77,7 +75,7 @@ var cli = new AppService.Cli({
     });
     log.info("AppServ", "Started listening on port %s at %s", port, new Date().toUTCString() );
 
-    var tstorage = new TwitterDB(config.bridge.database_file || "twitter.db");
+    const tstorage = new TwitterDB(config.bridge.database_file || "twitter.db");
 
     if (config.metrics && config.metrics.enable) {
       bridge.getPrometheusMetrics();
@@ -85,7 +83,7 @@ var cli = new AppService.Cli({
     }
 
     twitter = new Twitter(bridge, config, tstorage);
-    var opt = {
+    const opt = {
       bridge: bridge,
       app_auth: config.app_auth,
       storage: tstorage,
@@ -93,7 +91,7 @@ var cli = new AppService.Cli({
       sender_localpart: regObj.sender_localpart
     }
     const account_services = new RoomHandlers.AccountServices(opt);
-    room_handler = new TwitterRoomHandler(bridge, config,
+    const room_handler = new TwitterRoomHandler(bridge, config,
       {
         services: account_services,
         timeline: new RoomHandlers.TimelineHandler(bridge, twitter),
@@ -101,7 +99,7 @@ var cli = new AppService.Cli({
         directmessage: new RoomHandlers.DirectMessageHandler(bridge, twitter, tstorage)
       }
     );
-    var roomstore;
+    let roomstore;
     tstorage.init().then(() => {
       return twitter.start();
     }).then(() => {
@@ -129,17 +127,17 @@ var cli = new AppService.Cli({
     }).then((entries) => {
       entries.forEach((entry) => {
         if (entry.remote.data.hasOwnProperty('twitter_type')) {
-          var type = entry.remote.data.twitter_type;
+          const type = entry.remote.data.twitter_type;
 
           //Fix rooms that are alias rooms
           // Criteria: canonical_alias is #_twitter_@*+:domain
           if (type === "timeline" && entry.matrix.get("twitter_user") === null) {
             log.info("Init", `Checking ${entry.remote.getId()} to see if it's an alias room.`);
-            var stateLookup = new AppService.StateLookup(
+            const stateLookup = new AppService.StateLookup(
               {client: bridge.getIntent(), eventTypes: ["m.room.canonical_alias"]}
             );
             stateLookup.trackRoom(entry.matrix.getId()).then(() => {
-              var evt = stateLookup.getState(entry.matrix.getId(), "m.room.canonical_alias", "");
+              const evt = stateLookup.getState(entry.matrix.getId(), "m.room.canonical_alias", "");
               if(evt == null) {
                 return;
               }

--- a/twitter-as.js
+++ b/twitter-as.js
@@ -113,10 +113,10 @@ const cli = new AppService.Cli({
 
       // Setup twitbot profile (this is needed for some actions)
       bridge.getClientFactory().getClientAs().register(regObj.sender_localpart).then( () => {
-        log.info("Init", "Created user '"+regObj.sender_localpart+"'.");
+        log.info("Init", "Created user '" + regObj.sender_localpart + "'.");
       }).catch( (err) => {
         if (err.errcode !== "M_USER_IN_USE") {
-          log.info("Init", "Failed to create bot user '"+regObj.sender_localpart+"'. %s", err.errcode);
+          log.info("Init", "Failed to create bot user '" + regObj.sender_localpart + "'. %s", err.errcode);
         }
       });
 


### PR DESCRIPTION
Fixed issue where the feed queue would get stuck if no tweets were found.

---

This is one half of my commits to lower the amount of traffic going into synapse. This will (optionally) disable feeds which have no active real users. Essentially if all the rooms a feed is used in has no real users joined, we skip the feed.

**March edition** : The other half is also included, which checks too see if a huge member event spam attack is likely and forces the bridge to use a single user.