### PR TITLE
timeline.retweets option

### DIFF
--- a/src/TwitterDB.js
+++ b/src/TwitterDB.js
@@ -2,7 +2,7 @@ const SQLite3 = require('sqlite3').verbose();
 const log = require('./logging.js');
 const Promise = require('bluebird');
 
-const CURRENT_SCHEMA = 4;
+const CURRENT_SCHEMA = 5;
 /**
  * Stores data for specific users and data not specific to rooms.
  */

--- a/src/database_schema/v5.js
+++ b/src/database_schema/v5.js
@@ -1,0 +1,7 @@
+module.exports = {
+  run: function (twit_db) {
+    twit_db.db.exec(`
+      ALTER TABLE timeline_room  ADD COLUMN retweets TEXT NOT NULL DEFAULT "root";
+      `);
+  }
+}

--- a/src/db/event.js
+++ b/src/db/event.js
@@ -75,5 +75,23 @@ module.exports = {
       log.error("TwitDB", "Error checking room_has_tweet: %s", err.Error);
       throw err;
     });
+  },
+
+  room_retweets: function (room_id) {
+    log.silly("SQL", "room_retweets => %s", room_id);
+    return this.db.getAsync(
+      `
+      SELECT retweets
+      FROM timeline_room
+      WHERE room_id = $room_id
+      `
+    , {
+      $room_id: room_id
+    }).then(row => {
+      return row === undefined ? "root" : row.retweets;
+    }).catch( err => {
+      log.error("TwitDB", "Error getting room_retweets: %s", err.Error);
+      throw err;
+    });
   }
 }

--- a/src/db/timeline_room.js
+++ b/src/db/timeline_room.js
@@ -51,6 +51,22 @@ module.exports = {
       });
   },
 
+  set_timeline_retweets_option: function (room_id, retweets) {
+    log.silly("SQL", "set_timeline_retweets_option => %s, %s", room_id, retweets);
+    return this.db.runAsync(
+      `
+        UPDATE timeline_room
+        SET retweets = $retweets
+        WHERE room_id = $room_id;
+      `, {
+        $room_id: room_id,
+        $retweets: retweets
+      }).catch(err => {
+        log.error("TwitDB", "Error setting 'retweets' filter: %s", err.Error);
+        throw err;
+      });
+  },
+
   set_timeline_room: function (user_id, room_id, _with, replies) {
     log.silly("SQL", "set_timeline_room => %s", room_id);
     return this.db.runAsync(


### PR DESCRIPTION
I like to know who have done a retweet. I saw that you add this info in the source message, but it is not shown on Riot. So I propose to add a room option `timeline.retweets` to select how to show retweeted status:

- `root` (the default): show the retweeted status like any other status, this is the current behavior
- `rt`: show the status from the user doing the retweet, with `RT @user_retweeted: blabla`

I've added a column in the `timeline_room` table to save this parameter.

If the `rt` parameter is selected, we need to rewrite the the `tweet.text` field, because the original one can be truncated (and its a badly, truncating even links).

If my not really sure:
- about the fact of getting the parameter from the db for every tweet
- about the names `root` and `rt`